### PR TITLE
chore: update TheCatApiClient sample for WASM thread dispatch

### DIFF
--- a/UI/TheCatApiClient/TheCatApiClient/TheCatApiClient.Shared/Models/ViewModels/DispatchedBindableBase.cs
+++ b/UI/TheCatApiClient/TheCatApiClient/TheCatApiClient.Shared/Models/ViewModels/DispatchedBindableBase.cs
@@ -37,7 +37,16 @@ namespace TheCatApiClient.Shared.Models.ViewModels
         // Insert Dispatch below here
         protected async Task DispatchAsync(DispatchedHandler callback)
         {
-            if (Dispatcher.HasThreadAccess)
+            // As WASM is currently single-threaded, and Dispatcher.HasThreadAccess always returns false for broader compatibility reasons
+            // the following code ensures the local code always directly invokes the callback on WASM.
+            var hasThreadAccess =
+#if __WASM__
+                true;
+#else
+                Dispatcher.HasThreadAccess;
+#endif
+
+            if (hasThreadAccess)
             {
                 callback.Invoke();
             }


### PR DESCRIPTION
@ebariche During the review of the associated tutorial, a change to how thread access is handled when running under WASM was recommended by @davidjohnoliver .