### PR TITLE
Fix CORS error when launching UnoChat.Service locally.

### DIFF
--- a/UI/ChatSignalR/UnoChat.Service/Startup.cs
+++ b/UI/ChatSignalR/UnoChat.Service/Startup.cs
@@ -44,12 +44,12 @@ namespace UnoChat.Service
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
             }
+            app.UseCors("CorsPolicy");
 
             app.UseHttpsRedirection();
             app.UseStaticFiles();
 
             app.UseRouting();
-            app.UseCors("CorsPolicy");
 
             app.UseAuthorization();
 


### PR DESCRIPTION
Change to use UseCors step earlier in UnoChat.Service configuration so it works when launched locally.
Based on: https://stackoverflow.com/a/60469784

Was not working for me when I launched the service locally. Currently this uses an azure website as a chat hub which hides this issue. https://github.com/unoplatform/Uno.Samples/blob/5564c8f56dd41681e6b9213aa197de28a07bcee3/UI/ChatSignalR/UnoChat.Client/UnoChat.Client.Shared/ViewModel.cs#L71

When reverting to use localhost the problem appears.