### PR TITLE
fix: adjusting ports to avoid conflict

### DIFF
--- a/UI/UnoContoso/UnoContoso.Service/Properties/launchSettings.json
+++ b/UI/UnoContoso/UnoContoso.Service/Properties/launchSettings.json
@@ -23,7 +23,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:5000"
+      "applicationUrl": "http://localhost:2706"
     }
   }
 }

--- a/UI/UnoContoso/UnoContoso.Shared/App.xaml.cs
+++ b/UI/UnoContoso/UnoContoso.Shared/App.xaml.cs
@@ -237,9 +237,9 @@ namespace UnoContoso
 		public void UseRest(IContainerRegistry containerRegistry) 
 		{
 #if __ANDROID__
-            var repository = new RestContosoRepository("http://10.0.2.2:5000/api/");
+            var repository = new RestContosoRepository("http://10.0.2.2:2706/api/");
 #else
-            var repository = new RestContosoRepository("http://localhost:5000/api/");
+			var repository = new RestContosoRepository("http://localhost:2706/api/");
 #endif
             //var repository = new RestContosoRepository("https://unocontososervice20201016190520.azurewebsites.net/api/");
             containerRegistry.RegisterInstance<IContosoRepository>(repository);


### PR DESCRIPTION
closes #127 

Ports from WASM and Services projects were the same if using Kestrel. 