### PR TITLE
fix: Adjust SkiaSharp template for x:Bind error

### DIFF
--- a/UI/SkiaSharpTest/SkiaSharpTest/SkiaSharpTest.Shared/MainPage.xaml
+++ b/UI/SkiaSharpTest/SkiaSharpTest/SkiaSharpTest.Shared/MainPage.xaml
@@ -2,11 +2,13 @@
     x:Class="SkiaSharpTest.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:xamarin="http://uno.ui/xamarin"
     xmlns:local="using:SkiaSharpTest"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:skia="using:SkiaSharp.Views.UWP"
-    mc:Ignorable="d" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    mc:Ignorable="d xamarin"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
 		<Grid.RowDefinitions>
@@ -21,14 +23,14 @@
 			<skia:SKSwapChainPanel
 				x:Name="swapChain"
 				PaintSurface="OnPaintSwapChain"
-				PointerMoved="{x:Bind OnPointerMoved}" 
-				Background="Transparent"
+				PointerMoved="{x:Bind OnSurfacePointerMoved}"
+				xamarin:Background="Transparent"
 				Visibility="{x:Bind hwAcceleration.IsChecked, Mode=OneWay}" />
 			<skia:SKXamlCanvas 
 				x:Name="canvas" 
 				PaintSurface="OnPaintSurface"
-				PointerMoved="{x:Bind OnPointerMoved}"
-				Background="Transparent"
+				PointerMoved="{x:Bind OnSurfacePointerMoved}"
+				xamarin:Background="Transparent"
 				Visibility="{x:Bind Not(hwAcceleration.IsChecked), Mode=OneWay}" />
 		</Grid>
 	</Grid>

--- a/UI/SkiaSharpTest/SkiaSharpTest/SkiaSharpTest.Shared/MainPage.xaml.cs
+++ b/UI/SkiaSharpTest/SkiaSharpTest/SkiaSharpTest.Shared/MainPage.xaml.cs
@@ -51,7 +51,7 @@ namespace SkiaSharpTest
 			Render(canvas, new Size(info.Width, info.Height), SKColors.Yellow, "SkiaSharp Software Rendering");
 		}
 
-		private void OnPointerMoved(object sender, PointerRoutedEventArgs e)
+		private void OnSurfacePointerMoved(object sender, PointerRoutedEventArgs e)
         {
 			_currentPosition = e.GetCurrentPoint(panelGrid).Position;
 			currentPositionText.Text = _currentPosition.ToString();

--- a/UI/SkiaSharpTest/SkiaSharpTest/SkiaSharpTest.UWP/SkiaSharpTest.UWP.csproj
+++ b/UI/SkiaSharpTest/SkiaSharpTest/SkiaSharpTest.UWP/SkiaSharpTest.UWP.csproj
@@ -22,6 +22,9 @@
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.1.9" />
   </ItemGroup>
   <PropertyGroup>
+    <SynthesizeLinkMetadata>true</SynthesizeLinkMetadata>
+  </PropertyGroup>
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProjectGuid>{E798BA38-04BF-4085-96ED-DE8C2C0D6AB1}</ProjectGuid>
@@ -31,7 +34,7 @@
     <AssemblyName>SkiaSharpTest</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
WMC1121: Invalid binding assignment : Events can only be bound to non-overloaded methods