### PR TITLE
fix: Remove extra brace

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -37,7 +37,7 @@ jobs:
       foreach ($SolutionName in $SolutionsToBuild) {
 
            $solutionPath=[System.IO.Path]::GetDirectoryName($SolutionName);
-           git diff --quiet HEAD "origin/$TargetBranch)" -- "$solutionPath"
+           git diff --quiet HEAD "origin/$TargetBranch" -- "$solutionPath"
 
            # Only build if there a change in the solution path for the current PR, if we're not in a PR
            if( ('$env:System_PullRequest_PullRequestId)' -eq '') -or ($global:LASTEXITCODE -ne 0)) {


### PR DESCRIPTION
Trailing brace is causing error in build
see https://dev.azure.com/uno-platform/Uno%20Platform/_build/results?buildId=60730&view=logs&j=b0e9e703-bc7b-5b6a-2ec3-61742e5311eb&t=e4987f70-9797-5667-3e14-6d3b01ce7da1&l=286