### PR TITLE
Fix: Make LoginViewModel public

### DIFF
--- a/reference/Commerce/Commerce/Commerce/Presentation/LoginViewModel.cs
+++ b/reference/Commerce/Commerce/Commerce/Presentation/LoginViewModel.cs
@@ -6,7 +6,7 @@ public partial record LoginViewModel
 {
 	private readonly INavigator _navigator;
 
-	private LoginViewModel(
+	public LoginViewModel(
 		INavigator navigator,
 		IOptions<AppInfo> appInfo)
 	{


### PR DESCRIPTION
Running the application, the login page (LoginPage) appears, but no viewmodel il bound to the view.
Make LoginViewModel public, so that it can be injected and bound to the LoginPage