### PR TITLE
fix: empty pages

### DIFF
--- a/reference/Commerce/Commerce/Commerce/Commerce.csproj
+++ b/reference/Commerce/Commerce/Commerce/Commerce.csproj
@@ -65,7 +65,13 @@
 		<EmbeddedResource Include="appsettings.json" />
 		<EmbeddedResource Include="appsettings.*.json" DependentUpon="appsettings.json" />
 		<UpToDateCheckInput Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
-		
+
+		<None Update="products.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Update="reviews.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>		
 	</ItemGroup>
 	
 	<!-- Workaround to avoid including Uno.Toolkit.UI XBFs in the PRI file -->

--- a/reference/Commerce/Commerce/Commerce/Commerce.csproj
+++ b/reference/Commerce/Commerce/Commerce/Commerce.csproj
@@ -7,7 +7,7 @@
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
 	</PropertyGroup>
 	<ItemGroup>
-		
+
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
 		<PackageReference Include="Uno.Dsp.Tasks" Version="1.1.0" />
 		<PackageReference Include="Uno.WinUI" Version="4.9.26" />
@@ -37,7 +37,7 @@
 		<PackageReference Include="Uno.Extensions.Reactive" Version="2.4.2" />
 		<PackageReference Include="Uno.Extensions.Reactive.Messaging" Version="2.4.2" />
 		<PackageReference Include="Uno.Extensions.Toolkit.WinUI" Version="2.4.2" />
-	
+
 	</ItemGroup>
 	<Choose>
 		<When Condition="$(IsWinAppSdk)">
@@ -59,21 +59,20 @@
 	</Choose>
 
 	<ItemGroup>
-		
+
 		<UnoDspImportColors Include="Styles\*.zip" Generator="Xaml" />
 		<UnoImage Include="Assets\**\*.svg" />
 		<EmbeddedResource Include="appsettings.json" />
 		<EmbeddedResource Include="appsettings.*.json" DependentUpon="appsettings.json" />
 		<UpToDateCheckInput Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
-
-		<None Update="products.json">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>
-		<None Update="reviews.json">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</None>		
 	</ItemGroup>
-	
+
+	<ItemGroup>
+		<None Remove="*.json" />
+		<Content Include="*.json" />
+	</ItemGroup>
+
+
 	<!-- Workaround to avoid including Uno.Toolkit.UI XBFs in the PRI file -->
 	<!--<Target Name="AdjustGetPackagingOutput1" AfterTargets="GetMrtPackagingOutputs">
 		<Message Importance="high" Text="Applying NuGet packaging workaround for dependent PRI files exclusion" />

--- a/reference/Commerce/Commerce/Commerce/Data/ProductEndpoint.cs
+++ b/reference/Commerce/Commerce/Commerce/Data/ProductEndpoint.cs
@@ -2,8 +2,8 @@
 
 public class ProductEndpoint : IProductEndpoint
 {
-	public const string ProductDataFile = "products.json";
-	private const string ReviewDataFile = "reviews.json";
+	public const string ProductDataFile = "Commerce/products.json";
+	private const string ReviewDataFile = "Commerce/reviews.json";
 
 	private readonly IStorage _dataService;
 	private readonly ISerializer _serializer;


### PR DESCRIPTION
This PR ensures 'products.json' and 'reviews.json' are copied to the output directory at runtime, resolving a file access issue that made the pages empty.

#415 