### PR TITLE
fix: autosuggest layout on Mobile

### DIFF
--- a/UI/AutoSuggestSample/AutoSuggestSample/AutoSuggestSample.Shared/MainPage.xaml
+++ b/UI/AutoSuggestSample/AutoSuggestSample/AutoSuggestSample.Shared/MainPage.xaml
@@ -9,14 +9,17 @@
     >
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
-          Margin="50">
-        <StackPanel>
-            <TextBlock Text="This sample demonstrates the use of the AutoSuggestBox Control" Margin="0,0,0,30" FontSize="30" />
+          Margin="20,40">
+        <StackPanel Margin="4">
+            <TextBlock Text="This sample demonstrates the use of the AutoSuggestBox Control" 
+                       Margin="0,0,0,30" 
+                       FontSize="30"
+                       TextWrapping="WrapWholeWords" />
             <AutoSuggestBox x:Name="suggestBox"
-							Header="Type in some text:"
-							TextChanged="OnTextChanged"
-							QuerySubmitted="OnQuerySubmitted"
-							SuggestionChosen="OnSuggestionChosen" />
+		            Header="Type in some text:"
+                            TextChanged="OnTextChanged"
+			    QuerySubmitted="OnQuerySubmitted"
+			    SuggestionChosen="OnSuggestionChosen" />
             <TextBlock x:Name="query" />
         </StackPanel>
     </Grid>


### PR DESCRIPTION
closes #441 

Adding TextWrapping and changing Margins on the main page of the AutoSuggestLayout.

![image](https://github.com/unoplatform/Uno.Samples/assets/70542961/7af9d624-71ea-4459-9bfb-c2f640dffbd1)
