### PR TITLE
fix: add spacing at top of Benchmark sample

### DIFF
--- a/UI/Benchmark/AppBenchmark/AppBenchmark.Mobile/AppBenchmark.Mobile.csproj
+++ b/UI/Benchmark/AppBenchmark/AppBenchmark.Mobile/AppBenchmark.Mobile.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
 	  <PackageReference Include="Uno.BenchmarkDotNet" Version="0.11.7-develop" />
 	  <PackageReference Include="Uno.BenchmarkDotNet.Annotations" Version="0.11.7-develop" />
+	  <PackageReference Include="Uno.Toolkit.WinUI" Version="3.0.5" />
 	  <PackageReference Include="Uno.WinUI" Version="4.9.26" />
     <PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.26" Condition="'$(Configuration)'=='Debug'" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.26" />

--- a/UI/Benchmark/AppBenchmark/AppBenchmark.Shared/MainPage.xaml
+++ b/UI/Benchmark/AppBenchmark/AppBenchmark.Shared/MainPage.xaml
@@ -5,10 +5,11 @@
     xmlns:local="using:AppBenchmark"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:utu="using:Uno.Toolkit.UI"
     mc:Ignorable="d"    
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid>
+    <Grid utu:SafeArea.Insets="Top,Bottom">
         <local:BenchmarkDotNetControl />
     </Grid>
 </Page>

--- a/UI/Benchmark/AppBenchmark/AppBenchmark.Wasm/AppBenchmark.Wasm.csproj
+++ b/UI/Benchmark/AppBenchmark/AppBenchmark.Wasm/AppBenchmark.Wasm.csproj
@@ -47,6 +47,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.1" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="3.0.5" />
 		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.9.26" />
 		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.26" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.26" />

--- a/UI/Benchmark/AppBenchmark/AppBenchmark.Windows/AppBenchmark.Windows.csproj
+++ b/UI/Benchmark/AppBenchmark/AppBenchmark.Windows/AppBenchmark.Windows.csproj
@@ -30,6 +30,7 @@
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
 		<PackageReference Include="Uno.Core.Extensions.Logging.Singleton" Version="4.0.1" />
+		<PackageReference Include="Uno.Toolkit.WinUI" Version="3.0.5" />
 
 		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>


### PR DESCRIPTION
closes #443 

Added SafeArea to the top & bottom of the Benchmark's sample main page.

![image](https://github.com/unoplatform/Uno.Samples/assets/70542961/5477b1d2-0f7f-4b3c-a6df-1e9873c0f806)
