### PR TITLE
fix: changed windows background brush for migratingeffects sample

### DIFF
--- a/UI/MigratingEffects/UnoEffectsSample/UnoEffectsSample/MainPage.xaml
+++ b/UI/MigratingEffects/UnoEffectsSample/UnoEffectsSample/MainPage.xaml
@@ -6,7 +6,7 @@
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	mc:Ignorable="d"
-	Background="{ThemeResource BackgroundBrush}">
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
 	<StackPanel HorizontalAlignment="Stretch"
 				VerticalAlignment="Top" Margin="16" Spacing="16">


### PR DESCRIPTION
closes #467 

The resource key BackgroundBrush was not found on the MainPage. Replaced it with the ApplicationPageBackgroundThemeBrush.