### PR TITLE
fix: CatApiClient mobile layout

### DIFF
--- a/UI/TheCatApiClient/TheCatApiClient/TheCatApiClient.Shared/MainPage.xaml
+++ b/UI/TheCatApiClient/TheCatApiClient/TheCatApiClient.Shared/MainPage.xaml
@@ -27,8 +27,10 @@
 			<!-- ROW 0 - Title -->
 			<StackPanel>
 				<TextBlock Text="The Cat API Client"
-						   Style="{StaticResource HeaderTextBlockStyle}" />
-				<TextBlock Text="To run this sample go to https://www.thecatapi.com/ and register for an API key and replace YOUR-API-KEY in the code with your API key" />
+				           Style="{StaticResource HeaderTextBlockStyle}"
+                           		   TextWrapping="WrapWholeWords" />
+				<TextBlock Text="To run this sample go to https://www.thecatapi.com/ and register for an API key and replace YOUR-API-KEY in the code with your API key"
+                           	           TextWrapping="WrapWholeWords" />
 			</StackPanel>
 
 			<!-- ROW 1 - Search Box -->


### PR DESCRIPTION
closes #512 

Title text and description text is no longer truncated on Mobile (added wrapping).