### PR TITLE
fix: added slider content back

### DIFF
--- a/UI/MvuxHowTos/SliderApp/SliderApp/MainPage.xaml
+++ b/UI/MvuxHowTos/SliderApp/SliderApp/MainPage.xaml
@@ -1,14 +1,29 @@
 <Page x:Class="SliderApp.MainPage"
-	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:local="using:SliderApp"
-	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	mc:Ignorable="d"
-	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:SliderApp">
 
-	<StackPanel HorizontalAlignment="Center"
-				VerticalAlignment="Center">
-		<TextBlock Text="Hello Uno Platform" />
-	</StackPanel>
+    <Page.DataContext>
+        <local:BindableSliderModel />
+    </Page.DataContext>
+
+    <StackPanel>
+        <StackPanel Orientation="Horizontal"
+                    Spacing="5">
+            <TextBlock Text="Current state value:" />
+            <TextBlock Text="{Binding SliderValue}" />
+        </StackPanel>
+
+        <Border Height="1"
+                Background="DarkGray" />
+
+        <TextBlock Text="Set state value:" />
+        <Slider Value="{Binding SliderValue, Mode=TwoWay}" />
+
+        <Button Content="Reset slider"
+                Command="{Binding ResetSlider}" />
+        <Button Content="Increment slider"
+                Command="{Binding IncrementSlider}" />
+
+    </StackPanel>
 </Page>


### PR DESCRIPTION
closes #496 

Added Slider content back to the sample app. Disregard this PR if we do not want this slider anymore. (took it from this commit: https://github.com/unoplatform/Uno.Samples/commit/fbfddcce5169a3e577913e32f6cbe655899472b6#diff-2c972e423ada7e5655973a8f3761a0949a302309026b1699c5fa2ae6eef42de5)