### PR TITLE
fix: wasm deadlock for ChatSignalR

### DIFF
--- a/UI/ChatSignalR/UnoChat.Client/UnoChat.Shared/ViewModel.cs
+++ b/UI/ChatSignalR/UnoChat.Client/UnoChat.Shared/ViewModel.cs
@@ -217,14 +217,16 @@ namespace UnoChat.Client
                 .Where(args => args.Action == NotifyCollectionChangedAction.Add)
                 .Select(args => args.NewItems.OfType<Message.Model>().FirstOrDefault())
                 .Where(model => model != null)
+#if !__WASM__
                 .Delay(TimeSpan.FromMilliseconds(10), Schedulers.Default) // Wait for the list view to have been updated
+#endif
                 .ObserveOn(Schedulers.Dispatcher)
                 .Subscribe(messageObserver);
         }
 
         public IDisposable Activate(IObservable<object> messageToSendBoxReturn, IObserver<string> themeObserver, IObserver<Message.Model> messageObserver)
         {
-            return new CompositeDisposable(
+			return new CompositeDisposable(
                 ShouldUpdateStateWhenHubStateChanges(),
                 ShouldEnableConnectWhenNotConnected(),
                 ShouldEnableMessageToSendWhenConnected(),


### PR DESCRIPTION
#430 

This draft is to show where the problem is. Merging this PR would allow the app to deploy properly on WASM, but this is probably not the correct solution to solve this. 

@nickrandolph 