### PR TITLE
ci: Try to skip keep alives

### DIFF
--- a/UI/XamlBrewerUnoApp/XamlBrewerUnoApp/XamlBrewerUnoApp/Shell.xaml.cs
+++ b/UI/XamlBrewerUnoApp/XamlBrewerUnoApp/XamlBrewerUnoApp/Shell.xaml.cs
@@ -39,6 +39,7 @@ namespace XamlBrewerUnoApp
                 root.RequestedTheme = settings.IsLightTheme ? ElementTheme.Light : ElementTheme.Dark;
             };
         }
+
         private void Root_ActualThemeChanged(FrameworkElement sender, object args)
         {
             // Theme change refinements (e.g. content dialogs and title bar).

--- a/build-samples.yml
+++ b/build-samples.yml
@@ -23,7 +23,7 @@ steps:
       Set-PSDebug -Trace 1
       Write-Host "${{ parameters.path }}"
 
-      & $env:msbuildpath "${{ parameters.path }}" /r /p:Configuration=Release /p:WasmShellMonoRuntimeExecutionMode=Interpreter /p:PublishTrimmed=false /p:WasmShellILLinkerEnabled=false /p:RunAOTCompilation=false /p:MtouchUseLlvm=false /ds "/bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog" ;
+      & $env:msbuildpath "${{ parameters.path }}" /r /p:AndroidAddKeepAlives=false /p:Configuration=Release /p:WasmShellMonoRuntimeExecutionMode=Interpreter /p:PublishTrimmed=false /p:WasmShellILLinkerEnabled=false /p:RunAOTCompilation=false /p:MtouchUseLlvm=false /ds "/bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog" ;
 
       $folderPath = [System.IO.Path]::GetDirectoryName("${{ parameters.path }}");
 

--- a/build-samples.yml
+++ b/build-samples.yml
@@ -19,6 +19,9 @@ steps:
       echo "##vso[task.setvariable variable=msbuildpath]$msbuildpath"
   displayName: Set MSBUILDPATH
 
+# NOTE: Currently, the CI just validates that the sample builds, and we don't publish actual apps.
+# In future, if we publish actual apps, it could happen that AndroidAddKeepAlives=false may cause issues.
+# So it will be safer to remove it. For now, we set it to false as it makes the build much faster.
 - powershell: |
       Set-PSDebug -Trace 1
       Write-Host "${{ parameters.path }}"


### PR DESCRIPTION
This flag makes `LinkAssembliesNoShrink` run a lot faster. It takes it down from 9 minutes to 3 seconds!