### PR TITLE
chore: remove api key

### DIFF
--- a/reference/TubePlayer/TubePlayer/appsettings.development.json
+++ b/reference/TubePlayer/TubePlayer/appsettings.development.json
@@ -4,7 +4,7 @@
   },
   "YoutubeEndpoint": {
     "Url": "https://youtube.googleapis.com/youtube/v3",
-    "ApiKey": "yCrGWZY35SDZ7M2x7FSUP6QXCrjwLic78ZzyGFb",
+    "ApiKey": "YOUR-API-KEY-HERE",
     "UseNativeHandler": true
   },
   "YoutubePlayerEndpoint": {


### PR DESCRIPTION
The API Key that was there has surely already been scraped by bots and harvested for all its requests as I am just seeing the Error state now if I run this app as is. We should leave this as a placeholder