### PR TITLE
fix: Allow VS Code (with C# dev kit) to load SimpleCalculator solution

### DIFF
--- a/reference/SimpleCalc/MVU-X-CSharp/SimpleCalculator.Windows/SimpleCalculator.Windows.csproj
+++ b/reference/SimpleCalc/MVU-X-CSharp/SimpleCalculator.Windows/SimpleCalculator.Windows.csproj
@@ -9,7 +9,7 @@
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
-    <!-- <EnableWindowsTargeting>true</EnableWindowsTargeting> -->
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
     <!-- Bundles the WinAppSDK binaries -->
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>

--- a/reference/SimpleCalc/MVU-X-CSharp/SimpleCalculator.Windows/SimpleCalculator.Windows.csproj
+++ b/reference/SimpleCalc/MVU-X-CSharp/SimpleCalculator.Windows/SimpleCalculator.Windows.csproj
@@ -9,6 +9,7 @@
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
+    <!-- <EnableWindowsTargeting>true</EnableWindowsTargeting> -->
 
     <!-- Bundles the WinAppSDK binaries -->
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>

--- a/reference/SimpleCalc/MVU-X-Xaml/SimpleCalculator.Windows/SimpleCalculator.Windows.csproj
+++ b/reference/SimpleCalc/MVU-X-Xaml/SimpleCalculator.Windows/SimpleCalculator.Windows.csproj
@@ -9,6 +9,7 @@
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
     <!-- Bundles the WinAppSDK binaries -->
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>

--- a/reference/SimpleCalc/MVVM-CSharp/SimpleCalculator.Windows/SimpleCalculator.Windows.csproj
+++ b/reference/SimpleCalc/MVVM-CSharp/SimpleCalculator.Windows/SimpleCalculator.Windows.csproj
@@ -9,6 +9,7 @@
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
     <!-- Bundles the WinAppSDK binaries -->
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>

--- a/reference/SimpleCalc/MVVM-Xaml/SimpleCalculator.Windows/SimpleCalculator.Windows.csproj
+++ b/reference/SimpleCalc/MVVM-Xaml/SimpleCalculator.Windows/SimpleCalculator.Windows.csproj
@@ -9,6 +9,7 @@
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
     <!-- Bundles the WinAppSDK binaries -->
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>


### PR DESCRIPTION
Fix for templates https://github.com/unoplatform/uno.templates/pull/494
