### PR TITLE
Fix ScrollBars behavior

### DIFF
--- a/UI/PhotoViewer/InteractionControls/ZoomContentControl.cs
+++ b/UI/PhotoViewer/InteractionControls/ZoomContentControl.cs
@@ -226,6 +226,14 @@ public partial class ZoomContentControl : ContentControl
             ResetOffset();
             ResetZoom();
         }
+        if (_scrollH is not null)
+        {
+            _scrollH.Visibility = IsActive ? Visibility.Visible : Visibility.Collapsed;
+        }
+        if (_scrollV is not null)
+        {
+            _scrollV.Visibility = IsActive ? Visibility.Visible : Visibility.Collapsed;
+        }
     }
 
     private void UpdateScrollLimits()
@@ -433,20 +441,14 @@ public partial class ZoomContentControl : ContentControl
 
     public void ResetZoom()
     {
-        if (IsAllowedToWork)
-        {
-            ZoomLevel = 1;
-            HorizontalZoomCenter = 0;
-            VerticalZoomCenter = 0;
-        }
+        ZoomLevel = 1;
+        HorizontalZoomCenter = 0;
+        VerticalZoomCenter = 0;
     }
 
     public void ResetOffset()
     {
-        if (IsAllowedToWork)
-        {
-            HorizontalOffset = 0;
-            VerticalOffset = 0;
-        }
+        HorizontalOffset = 0;
+        VerticalOffset = 0;
     }
 }

--- a/UI/PhotoViewer/InteractionControls/ZoomContentControl.xaml
+++ b/UI/PhotoViewer/InteractionControls/ZoomContentControl.xaml
@@ -48,7 +48,8 @@
 							Minimum="{TemplateBinding VerticalMinScroll}"
 							Orientation="Vertical"
 							SmallChange="1"
-							ViewportSize="{TemplateBinding ViewPortHeight}" />
+							ViewportSize="{TemplateBinding ViewPortHeight}"
+							Value="{TemplateBinding VerticalScrollValue}" />
 						<!--  Horizontal ScrollBar  -->
 						<ScrollBar
 							x:Name="PART_scrollH"
@@ -62,7 +63,8 @@
 							Minimum="{TemplateBinding HorizontalMinScroll}"
 							Orientation="Horizontal"
 							SmallChange="1"
-							ViewportSize="{TemplateBinding ViewPortWidth}" />
+							ViewportSize="{TemplateBinding ViewPortWidth}"
+							Value="{TemplateBinding HorizontalScrollValue}" />
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>


### PR DESCRIPTION
Fixes #651 

ScrollBars were not accepting inverted values, so we had to handle that.
Also, TemplateBinding doesn't allow TwoWay mode, leading to change the values when scrolling the bars.