### PR TITLE
Literal adjusts and PointScroll response

### DIFF
--- a/UI/PhotoViewer/InteractionControls/ZoomContentControl.cs
+++ b/UI/PhotoViewer/InteractionControls/ZoomContentControl.cs
@@ -7,12 +7,22 @@ using Windows.Foundation;
 
 namespace InteractionControls;
 
-[TemplatePart(Name = "PART_Grid", Type = typeof(Grid))]
-[TemplatePart(Name = "PART_Presenter", Type = typeof(ContentPresenter))]
-[TemplatePart(Name = "PART_scrollV", Type = typeof(ScrollBar))]
-[TemplatePart(Name = "PART_scrollH", Type = typeof(ScrollBar))]
+[TemplatePart(Name = Parts.RootGrid, Type = typeof(Grid))]
+[TemplatePart(Name = Parts.Presenter, Type = typeof(ContentPresenter))]
+[TemplatePart(Name = Parts.VerticalScrollBar, Type = typeof(ScrollBar))]
+[TemplatePart(Name = Parts.HorizontalScrollBar, Type = typeof(ScrollBar))]
 public partial class ZoomContentControl : ContentControl
 {
+    private static class Parts
+    {
+        public const string RootGrid = "PART_RootGrid";
+
+        public const string Presenter = "PART_Presenter";
+
+        public const string HorizontalScrollBar = "PART_ScrollH";
+        public const string VerticalScrollBar = "PART_ScrollV";
+    }
+
     private Grid? _grid;
     private ContentPresenter? _presenter;
     private ScrollBar? _scrollV;
@@ -301,10 +311,10 @@ public partial class ZoomContentControl : ContentControl
 
     protected override void OnApplyTemplate()
     {
-        _grid = GetTemplateChild("PART_Grid") as Grid;
-        _presenter = GetTemplateChild("PART_Presenter") as ContentPresenter;
-        _scrollV = GetTemplateChild("PART_scrollV") as ScrollBar;
-        _scrollH = GetTemplateChild("PART_scrollH") as ScrollBar;
+        _grid = GetTemplateChild(Parts.RootGrid) as Grid;
+        _presenter = GetTemplateChild(Parts.Presenter) as ContentPresenter;
+        _scrollV = GetTemplateChild(Parts.VerticalScrollBar) as ScrollBar;
+        _scrollH = GetTemplateChild(Parts.HorizontalScrollBar) as ScrollBar;
 
         RegisterToControlEvents();
 

--- a/UI/PhotoViewer/InteractionControls/ZoomContentControl.xaml
+++ b/UI/PhotoViewer/InteractionControls/ZoomContentControl.xaml
@@ -7,7 +7,7 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="ctl:ZoomContentControl">
-					<Grid x:Name="PART_Grid">
+					<Grid x:Name="PART_RootGrid" Background="Transparent">
 						<Grid.RowDefinitions>
 							<RowDefinition Height="*" />
 							<RowDefinition Height="Auto" />
@@ -35,7 +35,7 @@
 						</ContentPresenter>
 						<!--  Vertical ScrollBar  -->
 						<ScrollBar
-							x:Name="PART_scrollV"
+							x:Name="PART_ScrollV"
 							Grid.Row="0"
 							Grid.Column="1"
 							HorizontalAlignment="Right"
@@ -51,7 +51,7 @@
 							Value="{TemplateBinding VerticalScrollValue}" />
 						<!--  Horizontal ScrollBar  -->
 						<ScrollBar
-							x:Name="PART_scrollH"
+							x:Name="PART_ScrollH"
 							Grid.Row="1"
 							Grid.Column="0"
 							HorizontalAlignment="Stretch"


### PR DESCRIPTION
Small adjustments to literals and also solve a regression when scrolling out of the actual element of interest, but still inside ZoomContentControl.