### PR TITLE
fix: ChatSignalR - stop hang on WASM

### DIFF
--- a/UI/ChatSignalR/UnoChat.Client/UnoChat.Shared/ViewModel.cs
+++ b/UI/ChatSignalR/UnoChat.Client/UnoChat.Shared/ViewModel.cs
@@ -218,7 +218,10 @@ namespace UnoChat.Client
                 .Where(args => args.Action == NotifyCollectionChangedAction.Add)
                 .Select(args => args.NewItems.OfType<Message.Model>().FirstOrDefault())
                 .Where(model => model != null)
+
+#if !__WASM__
                 .Delay(TimeSpan.FromMilliseconds(10), Schedulers.Default) // Wait for the list view to have been updated
+#endif
                 .ObserveOn(Schedulers.Dispatcher)
                 .Subscribe(messageObserver);
 #else


### PR DESCRIPTION
rectified an issue with `Delay` which would cause a permanent hang in Web Assembly.  

perhaps a temporary fix, until `threading` in .NET 9, as alluded to by @jeromelaban [here](https://github.com/unoplatform/uno/issues/13370)  

for the ChatSignalR sample:
 - closes #417 
 - closes #430 
 
 - *should be the fix that* closes #118 
   - no connection issues once fixed.. the observed issue was likely the hang
   - the only connection changes I have ever had to make are to change the WASM port from 5000 to 5001- likely no relation  

