### PR TITLE
Show repository as mainly C# and not TSQL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.md merge=union
+*.sql linguist-detectable=false


### PR DESCRIPTION
change should make `TSQL` disappear as the main type of this repo:
![Screenshot 2024-05-30 at 09 57 41](https://github.com/unoplatform/Uno.Samples/assets/79252299/5c891199-ffe4-42ac-918b-f226572eaa76)

![Screenshot 2024-05-30 at 09 57 51](https://github.com/unoplatform/Uno.Samples/assets/79252299/dc8d4f7e-cbcc-436d-874f-278c405e06f9)

`C#` should then show, as the second largest portion, by type.

**Please note:** may take a few minutes post-merge for the repo to show as `C#`