### PR TITLE
fix(Settings): Wide layout and content for Narrow to avoid exceptions on Windows

### DIFF
--- a/reference/ToDo/src/ToDo/Views/Dialogs/SettingsFlyout.xaml
+++ b/reference/ToDo/src/ToDo/Views/Dialogs/SettingsFlyout.xaml
@@ -1,181 +1,152 @@
 ﻿<Flyout x:Class="ToDo.Views.Dialogs.SettingsFlyout"
-		xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-		xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-		xmlns:local="using:ToDo.Views.Dialogs"
-		xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-		xmlns:uen="using:Uno.Extensions.Navigation.UI"
-		xmlns:utu="using:Uno.Toolkit.UI"
-		xmlns:controls="using:ToDo.Controls"
-		Placement="Full"
-		LightDismissOverlayMode="On"
-		FlyoutPresenterStyle="{StaticResource FlyoutPresenterStyle}">
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="using:ToDo.Views.Dialogs"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:uen="using:Uno.Extensions.Navigation.UI"
+        xmlns:utu="using:Uno.Toolkit.UI"
+        xmlns:controls="using:ToDo.Controls"
+        Placement="Full"
+        LightDismissOverlayMode="On"
+        FlyoutPresenterStyle="{StaticResource FlyoutPresenterStyle}">
 
-	<UserControl x:Name="FlyoutControl">
-		<Grid x:Name="FlyoutRoot"
-			  Background="{ThemeResource SurfaceBrush}">
-			<VisualStateManager.VisualStateGroups>
-				<VisualStateGroup>
-					<VisualState x:Name="Wide">
-						<VisualState.StateTriggers>
-							<AdaptiveTrigger MinWindowWidth="{StaticResource WideMinWindowWidth}" />
-						</VisualState.StateTriggers>
-						<VisualState.Setters>
-							<Setter Target="FlyoutRoot.MinWidth"
-									Value="500" />
-							<Setter Target="FlyoutRoot.CornerRadius"
-									Value="28" />
-							<Setter Target="FlyoutRoot.HorizontalAlignment"
-									Value="Center" />
-							<Setter Target="FlyoutRoot.VerticalAlignment"
-									Value="Center" />
-						</VisualState.Setters>
-					</VisualState>
-				</VisualStateGroup>
-			</VisualStateManager.VisualStateGroups>
+  <UserControl x:Name="FlyoutControl">
+    <Grid x:Name="FlyoutRoot"
+          Background="{ThemeResource SurfaceBrush}">
+      <VisualStateManager.VisualStateGroups>
+        <VisualStateGroup>
+          <VisualState x:Name="Wide">
+            <VisualState.StateTriggers>
+              <AdaptiveTrigger MinWindowWidth="{StaticResource WideMinWindowWidth}" />
+            </VisualState.StateTriggers>
+            <VisualState.Setters>
+              <Setter Target="FlyoutRoot.MinWidth"
+                      Value="500" />
+              <Setter Target="FlyoutRoot.CornerRadius"
+                      Value="28" />
+              <Setter Target="FlyoutRoot.HorizontalAlignment"
+                      Value="Center" />
+              <Setter Target="FlyoutRoot.VerticalAlignment"
+                      Value="Center" />
+            </VisualState.Setters>
+          </VisualState>
+        </VisualStateGroup>
+      </VisualStateManager.VisualStateGroups>
 
-			<utu:AutoLayout>
-				<utu:AutoLayout utu:AutoLayout.PrimaryAlignment="Stretch">
-					<utu:NavigationBar x:Uid="SettingsFlyout_NavigationBar"
-									    Content="Settings"
-									    uen:Navigation.Request="-"
-									    Style="{StaticResource RootModalNavigationBarStyle}" />
-					<utu:AutoLayout Padding="20,15,20,0">
-						<utu:AutoLayout Spacing="10"
-										Padding="0,0,0,10"
-										Orientation="Horizontal">
-							<utu:AutoLayout Spacing="10"
-											Padding="20,15,20,15"
-											Orientation="Horizontal"
-											utu:AutoLayout.PrimaryAlignment="Stretch" />
-							<PersonPicture DisplayName="{Binding CurrentUser.Name}"
-										    ProfilePicture="{Binding ProfilePicture, Converter={StaticResource  BitmapSourceConverter}}"
-										    utu:AutoLayout.CounterAlignment="Start" />
-							<utu:AutoLayout Spacing="10"
-											Padding="20,15,20,15"
-											Orientation="Horizontal"
-											utu:AutoLayout.PrimaryAlignment="Stretch" />
-						</utu:AutoLayout>
-						<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
-								    TextAlignment="Center"
-								    TextWrapping="Wrap"
-								    Text="{Binding CurrentUser.Name}"
-								    Style="{StaticResource TitleLarge}" />
-						<TextBlock Foreground="{ThemeResource OnSurfaceMediumBrush}"
-								    TextAlignment="Center"
-								    TextWrapping="Wrap"
-								    Text="{Binding CurrentUser.Email}"
-								    Style="{StaticResource BodyMedium}" />
-						<Button x:Uid="SettingsFlyout_SignOutButton"
-								Content="sign out"
-								Command="{Binding SignOut}"
-								Foreground="{ThemeResource ErrorBrush}"
-								Style="{StaticResource TextButtonStyle}" />
-					</utu:AutoLayout>
-					<utu:AutoLayout Padding="20,0,20,0"
-									utu:AutoLayout.PrimaryAlignment="Stretch">
-						<utu:AutoLayout Spacing="5"
-										utu:AutoLayout.PrimaryAlignment="Stretch">
-							<utu:AutoLayout Spacing="5"
-											Padding="0,10,0,10">
-								<utu:Divider Style="{StaticResource DividerStyle}" />
-							</utu:AutoLayout>
-							<TextBlock x:Uid="SettingsFlyout_GeneralSection"
-									    Text="General"
-									    TextWrapping="Wrap"
-									    Foreground="{ThemeResource PrimaryBrush}"
-									    Style="{StaticResource LabelLarge}" />
-							<utu:AutoLayout Spacing="20">
-								<!-- Commenting the Color Palette Section for now -->
-								<!-- Can be added again when it's implemented : https://github.com/unoplatform/uno.todo/issues/147 -->
-								<!--<utu:AutoLayout Spacing="5">
-							<TextBlock x:Uid="SettingsFlyout_PaletteSection"
-									    Text="Color palette"
-									    Foreground="{ThemeResource OnSurfaceBrush}"
-									    utu:AutoLayout.CounterAlignment="Start"
-									    Style="{StaticResource BodySmall}" />
-							<utu:ChipGroup x:Name="ColorPaletteChipGroup"
-										    SelectionMode="Single"
-										    ItemChecked="{x:Bind UpdateAppColorPalette}"
-										    Style="{StaticResource FilterChipGroupStyle}">
-								<utu:Chip x:Uid="SettingsFlyout_PalettePurple" Content="Purple"
-										  Style="{StaticResource FilterChipStyle}" />
-								<utu:Chip x:Uid="SettingsFlyout_PaletteBlue" Content="Blue"
-										  Style="{StaticResource FilterChipStyle}" />
-								<utu:Chip x:Uid="SettingsFlyout_PaletteYellow" Content="Yellow"
-										  Style="{StaticResource FilterChipStyle}" />
-							</utu:ChipGroup>
-						</utu:AutoLayout>-->
-								<utu:AutoLayout Spacing="5">
-									<TextBlock x:Uid="SettingsFlyout_LanguageLabel"
-											    Foreground="{ThemeResource OnSurfaceBrush}"
-											    Text="Language"
-											    utu:AutoLayout.CounterAlignment="Start"
-											    Style="{StaticResource BodySmall}" />
-									<utu:ChipGroup x:Name="LanguageChipGroup"
-												    SelectionMode="Single"
-												    ItemsSource="{Binding Cultures}"
-												    SelectedItem="{Binding SelectedCulture, Mode=TwoWay}"
-												    Style="{StaticResource FilterChipGroupStyle}">
-										<utu:ChipGroup.ItemTemplate>
-											<DataTemplate>
-												<TextBlock Text="{Binding Display}" />
-											</DataTemplate>
-										</utu:ChipGroup.ItemTemplate>
-									</utu:ChipGroup>
-									<TextBlock x:Uid="SettingsFlyout_NoteToRestart"
-											    Foreground="{ThemeResource OnSurfaceMediumBrush}"
-											    Text="Change will be applied at next app restart"
-											    utu:AutoLayout.CounterAlignment="Start"
-											    Style="{StaticResource BodyMedium}" />
-								</utu:AutoLayout>
-								<utu:AutoLayout Spacing="5"
-                                utu:AutoLayout.CounterAlignment="Start">
-                  <TextBlock x:Uid="SettingsFlyout_ThemeLabel"
-											    Foreground="{ThemeResource OnSurfaceBrush}"
-											    Text="Mode"
-											    utu:AutoLayout.CounterAlignment="Start"
-											    Style="{StaticResource BodySmall}" />
-                  <utu:ChipGroup x:Name="ThemeChipGroup"
-												   SelectionMode="Single"
-												   ItemsSource="{Binding AppThemes}"
-												   SelectedItem="{Binding SelectedAppTheme, Mode=TwoWay}"
-                           ItemChecked="ThemeChipGroup_ItemChecked"
-												   Style="{StaticResource FilterChipGroupStyle}">
-                    <utu:ChipGroup.ItemTemplate>
-                      <DataTemplate>
-                        <TextBlock Text="{Binding}" />
-                      </DataTemplate>
-                    </utu:ChipGroup.ItemTemplate>
-                  </utu:ChipGroup>
-                </utu:AutoLayout>
-							</utu:AutoLayout>
-							<utu:AutoLayout Spacing="5"
-											Padding="0,10,0,10">
-								<utu:Divider Style="{StaticResource DividerStyle}" />
-							</utu:AutoLayout>
-							<TextBlock x:Uid="SettingsFlyout_AboutSection"
-									    Foreground="{ThemeResource PrimaryBrush}"
-									    TextWrapping="Wrap"
-									    Text="About"
-									    Style="{StaticResource LabelLarge}" />
-							<utu:AutoLayout Spacing="5"
-											Margin="0,0,0,24"
-											Orientation="Horizontal">
-								<TextBlock x:Uid="SettingsFlyout_VersionLabel"
-										    Text="Version"
-										    Foreground="{ThemeResource OnSurfaceBrush}"
-										    utu:AutoLayout.PrimaryAlignment="Stretch"
-										    Style="{StaticResource TitleMedium}" />
-								<TextBlock Foreground="{ThemeResource PrimaryBrush}"
-										    TextAlignment="End"
-										    Text="1.0"
-										    utu:AutoLayout.PrimaryAlignment="Stretch"
-										    Style="{StaticResource TitleMedium}" />
-							</utu:AutoLayout>
-						</utu:AutoLayout>
-					</utu:AutoLayout>
-				</utu:AutoLayout>
-			</utu:AutoLayout>
-		</Grid>
-	</UserControl>
+      <utu:AutoLayout>
+        <utu:NavigationBar x:Uid="SettingsFlyout_NavigationBar"
+                           Content="Settings"
+                           uen:Navigation.Request="-"
+                           Style="{StaticResource RootModalNavigationBarStyle}" />
+        <utu:AutoLayout Spacing="12"
+                        Margin="20,10,20,0">
+          <utu:AutoLayout PrimaryAxisAlignment="Center"
+                          CounterAxisAlignment="Center">
+            <PersonPicture DisplayName="{Binding CurrentUser.Name}"
+                           ProfilePicture="{Binding ProfilePicture, Converter={StaticResource BitmapSourceConverter}}"
+                           Width="60"
+                           Height="60" />
+          </utu:AutoLayout>
+          <utu:AutoLayout>
+            <TextBlock Text="{Binding CurrentUser.Name}"
+                       TextAlignment="Center"
+                       TextWrapping="Wrap"
+                       Foreground="{ThemeResource OnSurfaceBrush}"
+                       Style="{StaticResource TitleLarge}" />
+            <TextBlock Text="{Binding CurrentUser.Email}"
+                       TextAlignment="Center"
+                       TextWrapping="Wrap"
+                       Foreground="{ThemeResource OnSurfaceMediumBrush}" />
+          </utu:AutoLayout>
+          <Button Content="Sign Out"
+                  Command="{Binding SignOut}"
+                  x:Uid="SettingsFlyout_SignOutButton"
+                  HorizontalAlignment="Center"
+                  Foreground="{ThemeResource ErrorBrush}"
+                  Style="{StaticResource TextButtonStyle}" />
+          <utu:Divider Style="{StaticResource DividerStyle}" />
+        </utu:AutoLayout>
+        <utu:AutoLayout Spacing="12"
+                        Margin="20,10,20,0">
+          <TextBlock Text="General"
+                     x:Uid="SettingsFlyout_GeneralSection"
+                     TextWrapping="Wrap"
+                     utu:AutoLayout.CounterAlignment="Stretch"
+                     Foreground="{ThemeResource PrimaryBrush}"
+                     Style="{StaticResource LabelLarge}" />
+          <utu:AutoLayout Spacing="20"
+                          CounterAxisAlignment="Start"
+                          utu:AutoLayout.CounterAlignment="Start">
+            <utu:AutoLayout Spacing="5"
+                            CounterAxisAlignment="Start">
+              <TextBlock Text="Language"
+                         x:Uid="SettingsFlyout_LanguageLabel"
+                         TextWrapping="Wrap"
+                         Foreground="{ThemeResource OnSurfaceBrush}"
+                         Style="{StaticResource BodySmall}" />
+              <utu:ChipGroup x:Name="LanguageChipGroup"
+                             SelectionMode="Single"
+                             ItemsSource="{Binding Cultures}"
+                             SelectedItem="{Binding SelectedCulture, Mode=TwoWay}"
+                             Style="{StaticResource FilterChipGroupStyle}">
+                <utu:ChipGroup.ItemTemplate>
+                  <DataTemplate>
+                    <TextBlock Text="{Binding Display}" />
+                  </DataTemplate>
+                </utu:ChipGroup.ItemTemplate>
+              </utu:ChipGroup>
+              <TextBlock Text="Change will be applied at next app restart"
+                         x:Uid="SettingsFlyout_NoteToRestart"
+                         TextWrapping="Wrap"
+                         Foreground="{ThemeResource OnSurfaceMediumBrush}"
+                         Style="{StaticResource CaptionMedium}" />
+            </utu:AutoLayout>
+            <utu:AutoLayout Spacing="5"
+                            CounterAxisAlignment="Start">
+              <TextBlock Text="Mode"
+                         x:Uid="SettingsFlyout_ThemeLabel"
+                         TextWrapping="Wrap"
+                         Foreground="{ThemeResource OnSurfaceBrush}"
+                         Style="{StaticResource BodySmall}" />
+              <utu:ChipGroup x:Name="ThemeChipGroup"
+                             SelectionMode="Single"
+                             ItemsSource="{Binding AppThemes}"
+                             SelectedItem="{Binding SelectedAppTheme, Mode=TwoWay}"
+                             ItemChecked="ThemeChipGroup_ItemChecked"
+                             Style="{StaticResource FilterChipGroupStyle}">
+                <utu:ChipGroup.ItemTemplate>
+                  <DataTemplate>
+                    <TextBlock Text="{Binding}" />
+                  </DataTemplate>
+                </utu:ChipGroup.ItemTemplate>
+              </utu:ChipGroup>
+            </utu:AutoLayout>
+          </utu:AutoLayout>
+          <utu:Divider Style="{StaticResource DividerStyle}" />
+          <TextBlock Text="About"
+                     x:Uid="SettingsFlyout_AboutSection"
+                     TextWrapping="Wrap"
+                     utu:AutoLayout.CounterAlignment="Stretch"
+                     Foreground="{ThemeResource PrimaryBrush}"
+                     Style="{StaticResource LabelLarge}" />
+          <utu:AutoLayout Spacing="12"
+                          Margin="0,0,0,24"
+                          CounterAxisAlignment="Start"
+                          Orientation="Horizontal"
+                          utu:AutoLayout.CounterAlignment="Stretch"
+                          utu:AutoLayout.PrimaryAlignment="Stretch">
+            <TextBlock Text="Version"
+                       x:Uid="SettingsFlyout_VersionLabel"
+                       TextWrapping="Wrap"
+                       Foreground="{ThemeResource OnSurfaceBrush}"
+                       Style="{StaticResource TitleMedium}" />
+            <TextBlock Text="1.0"
+                       Margin="10,0,0,0"
+                       Foreground="{ThemeResource PrimaryBrush}"
+                       Style="{StaticResource TitleMedium}" />
+          </utu:AutoLayout>
+        </utu:AutoLayout>
+      </utu:AutoLayout>
+    </Grid>
+  </UserControl>
 </Flyout>


### PR DESCRIPTION
## Description
Fix Wide layout and content for Narrow to avoid exceptions on Windows for Settings Flyout

| Wide - BEFORE | Wide - AFTER |
|--------|--------|
|  ![wide-before](https://github.com/unoplatform/Uno.Samples/assets/16295702/3da7a483-188f-4d62-962c-39e4245fcd10) |  ![wide-after](https://github.com/unoplatform/Uno.Samples/assets/16295702/e148e822-e632-4a2f-b89f-ee39b0336a83) |