### PR TITLE
fix: `ZoomContentControl` in PhotoViewer not working

### DIFF
--- a/UI/PhotoViewer/PhotoViewer/AppResources.xaml
+++ b/UI/PhotoViewer/PhotoViewer/AppResources.xaml
@@ -5,6 +5,9 @@
     <!-- Load WinUI resources -->
     <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
 
+    <!-- Import ZoomContentControl style -->
+    <ResourceDictionary Source="ms-appx:///InteractionControls/ZoomContentControl.xaml" />
+
   </ResourceDictionary.MergedDictionaries>
   <!-- Add resources here -->
 


### PR DESCRIPTION
The `ZoomContentControl` is currently not working as reported https://github.com/unoplatform/uno.toolkit.ui/issues/1109#issuecomment-2223150212. The PhotoViewer was missing the import of the necessary styles, so the IsAllowedToWork returned false even when the switch should have enabled it.