### PR TITLE
fix: Wrong value for default theme & Opening Settings Flyout Changes App

### DIFF
--- a/reference/ToDo/src/ToDo/Presentation/SettingsViewModel.cs
+++ b/reference/ToDo/src/ToDo/Presentation/SettingsViewModel.cs
@@ -38,10 +38,12 @@ public partial class SettingsViewModel
         _themeService = themeService;
 
         AppThemes = new string[] { localizer["SettingsFlyout_ThemeLight"], localizer["SettingsFlyout_ThemeDark"] };
-
-        _ = dispatcher.TryEnqueue(() => {
-            _isDark = _themeService.IsDark;
-        });
+        
+#if WINDOWS
+        _ = dispatcher.TryEnqueue(() => { _isDark = _themeService.IsDark; });
+#else
+        _isDark = _themeService.IsDark;
+#endif
 
         Cultures = localizationConfiguration.Value!.Cultures!.Select(c => new DisplayCulture(localizer[$"SettingsFlyout_LanguageLabel_{c}"], c)).ToArray();
         SelectedCulture = State.Value(this, () => Cultures.FirstOrDefault(c => c.Culture == LocalizationSettings.CurrentCulture.ToString()) ?? Cultures.First());


### PR DESCRIPTION
fixes #778 and #780 

Wasm:
![todo-wasm](https://github.com/user-attachments/assets/6a2f3edc-615c-4110-8430-8a9a703df8a1)

Windows:
![todo-windows](https://github.com/user-attachments/assets/f424e873-0e8e-4e94-9c5d-ce007cb04e03)
