### PR TITLE
chore: Update ScottPlot samples to latest Uno.Sdk 5.3.108

### DIFF
--- a/UI/ScottPlot/QuickstartSample/global.json
+++ b/UI/ScottPlot/QuickstartSample/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "5.3.99"
+    "Uno.Sdk": "5.3.108"
   },
   "sdk":{
     "allowPrerelease": false

--- a/UI/ScottPlot/SignalPlotFiveMillionPointsSample/global.json
+++ b/UI/ScottPlot/SignalPlotFiveMillionPointsSample/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "5.3.99"
+    "Uno.Sdk": "5.3.108"
   },
   "sdk":{
     "allowPrerelease": false


### PR DESCRIPTION
Update ScottPlot samples to latest Uno.Sdk 5.3.108

Tested on all platforms