### PR TITLE
chore(Commerce): Update Directory.Build.props to remove unnecessary version override with Uno.Sdk 5.4

### DIFF
--- a/reference/Commerce/src/Directory.Build.props
+++ b/reference/Commerce/src/Directory.Build.props
@@ -12,11 +12,4 @@
     -->
     <NoWarn>$(NoWarn);NU1507;NETSDK1201;PRI257</NoWarn>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <UnoExtensionsVersion>4.1.24</UnoExtensionsVersion>
-    <UnoToolkitVersion>6.0.24</UnoToolkitVersion>
-    <UnoThemesVersion>5.0.13</UnoThemesVersion>
-    <UnoCSharpMarkupVersion>5.2.14</UnoCSharpMarkupVersion>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Related issue: https://github.com/unoplatform/Uno.Samples/issues/828
- Update Directory.Build.props to remove unnecessary version override with Uno.Sdk 5.4 for Commerce Sample