### PR TITLE
chore(Navigation): Update Directory.Build.props to remove unnecessary version override with Uno.Sdk 5.4

### DIFF
--- a/UI/Navigation/src/Directory.Build.props
+++ b/UI/Navigation/src/Directory.Build.props
@@ -5,11 +5,4 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NoWarn>$(NoWarn);NU1507;NETSDK1201;PRI257</NoWarn>
   </PropertyGroup>
-
-  <!-- See https://aka.platform.uno/using-uno-sdk#implicit-packages for more information regarding the Implicit Packages version properties. -->
-  <PropertyGroup>
-    <UnoExtensionsVersion>5.0.0-dev.316</UnoExtensionsVersion>
-    <UnoToolkitVersion>6.2.0-dev.37</UnoToolkitVersion>
-    <UnoThemesVersion>5.2.0-dev.15</UnoThemesVersion>
-  </PropertyGroup>
 </Project>

--- a/UI/Navigation/src/Navigation/Navigation.csproj
+++ b/UI/Navigation/src/Navigation/Navigation.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk">
   <PropertyGroup>
     <TargetFrameworks>
       net8.0-android;
@@ -19,7 +19,26 @@
     <!-- Versions -->
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <ApplicationVersion>1</ApplicationVersion>
+    <!--
+      If you encounter this error message:
 
+        error NETSDK1148: A referenced assembly was compiled using a newer version of Microsoft.Windows.SDK.NET.dll.
+        Please update to a newer .NET SDK in order to reference this assembly.
+
+      This means that the two packages below must be aligned with the "build" version number of
+      the "Microsoft.Windows.SDK.BuildTools" package above, and the "revision" version number
+      must be the highest found in https://www.nuget.org/packages/Microsoft.Windows.SDK.NET.Ref.
+    -->
+
+    <!-- Uno Platform 5.4 has been updated to use WinAppSDK 1.6, which necessitates a temporary version adjustment until newer versions of .NET 8 SDKs are released. -->
+    <!-- Comment this WindowsSdkPackageVersion line again once .NET SDK version 8.0.403 or later is available. -->
+    <!-- For more details, refer to: https://aka.platform.uno/migrate-from-previous#uno-platform-54 -->
+    <WindowsSdkPackageVersion>10.0.19041.38</WindowsSdkPackageVersion>
+
+    <!--
+      UnoFeatures let's you quickly add and manage implicit package references based on the features you want to use.
+      https://aka.platform.uno/singleproject-features
+    -->
     <UnoFeatures>
       Material;
       Hosting;

--- a/UI/Navigation/src/global.json
+++ b/UI/Navigation/src/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "5.4.0-dev.192"
+    "Uno.Sdk": "5.4.5"
   },
   "sdk": {
     "allowPrerelease": false


### PR DESCRIPTION
Related issue: https://github.com/unoplatform/Uno.Samples/issues/828

 - Update Directory.Build.props to remove unnecessary version override with Uno.Sdk 5.4 for Navigation sample