### PR TITLE
chore: Version bump of sample project

### DIFF
--- a/UI/MVUX/src/MVUX/App.xaml.cs
+++ b/UI/MVUX/src/MVUX/App.xaml.cs
@@ -61,7 +61,7 @@ public partial class App : Application
 		MainWindow = builder.Window;
 
 #if DEBUG
-		MainWindow.EnableHotReload();
+		MainWindow.UseStudio();
 #endif
 		MainWindow.SetWindowIcon();
 

--- a/UI/MVUX/src/MVUX/MVUX.csproj
+++ b/UI/MVUX/src/MVUX/MVUX.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Uno.Sdk">
+﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041;net8.0-browserwasm;net8.0-desktop;net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0-desktop;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.19041;net9.0-browserwasm;net9.0</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>
@@ -49,6 +49,7 @@
       Serialization;
       Localization;
       Navigation;
+			ThemeService;
     </UnoFeatures>
   </PropertyGroup>
 

--- a/UI/MVUX/src/MVUX/Presentation/FeedViewCommandSample/FeedViewCommandModel.cs
+++ b/UI/MVUX/src/MVUX/Presentation/FeedViewCommandSample/FeedViewCommandModel.cs
@@ -16,5 +16,5 @@ public partial class FeedViewCommandModel
 
 public class Item
 {
-	public string Text { get; set; }
+	public string? Text { get; set; }
 }

--- a/UI/MVUX/src/global.json
+++ b/UI/MVUX/src/global.json
@@ -1,6 +1,6 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
 	"msbuild-sdks": {
-		"Uno.Sdk": "5.4.5"
+		"Uno.Sdk": "5.6.54"
 	}
 }


### PR DESCRIPTION
discovered outdated Version and problem causing (non-nullable which might not got value after constructor) code and fixed it

switched the first target to be desktop since currenctly there is the android emulator bug so vs 2022 was not loading with this even the project code