### PR TITLE
chore(studio): bump gallery samples to Uno.Sdk.Private 6.7.0-dev.850

### DIFF
--- a/studio/claude-code-tracker/ClaudeCodeTracker/ClaudeCodeTracker.csproj
+++ b/studio/claude-code-tracker/ClaudeCodeTracker/ClaudeCodeTracker.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-browserwasm;net10.0-desktop</TargetFrameworks>
 

--- a/studio/claude-code-tracker/global.json
+++ b/studio/claude-code-tracker/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "Uno.Sdk": "6.7.0-dev.50"
+    "Uno.Sdk.Private": "6.7.0-dev.850"
   },
   "sdk": {
     "allowPrerelease": false

--- a/studio/claude-code-tracker/nuget.config
+++ b/studio/claude-code-tracker/nuget.config
@@ -4,5 +4,6 @@
     <clear />
     <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
     <add key="Features" value="https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/Features/nuget/v3/index.json" />
+    <add key="uno dev" value="https://pkgs.dev.azure.com/uno-platform/1dd81cbd-cb35-41de-a570-b0df3571a196/_packaging/unoplatformdev/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/studio/coffee-shop/BrewHouse/BrewHouse.csproj
+++ b/studio/coffee-shop/BrewHouse/BrewHouse.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-browserwasm;net10.0-desktop</TargetFrameworks>
 

--- a/studio/coffee-shop/global.json
+++ b/studio/coffee-shop/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "Uno.Sdk": "6.7.0-dev.50"
+    "Uno.Sdk.Private": "6.7.0-dev.850"
   },
   "sdk": {
     "allowPrerelease": false

--- a/studio/fit-app/FitBeginnerApp/FitBeginnerApp.csproj
+++ b/studio/fit-app/FitBeginnerApp/FitBeginnerApp.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-browserwasm;net10.0-desktop</TargetFrameworks>
 

--- a/studio/fit-app/global.json
+++ b/studio/fit-app/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "Uno.Sdk": "6.7.0-dev.50"
+    "Uno.Sdk.Private": "6.7.0-dev.850"
   },
   "sdk": {
     "allowPrerelease": false

--- a/studio/movie-streaming-app/MovieStreamApp/Assets/Icons/icon.svg
+++ b/studio/movie-streaming-app/MovieStreamApp/Assets/Icons/icon.svg
@@ -1,0 +1,3 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="240" height="240" fill="#151515"/>
+</svg>

--- a/studio/movie-streaming-app/MovieStreamApp/Assets/Icons/icon_foreground.svg
+++ b/studio/movie-streaming-app/MovieStreamApp/Assets/Icons/icon_foreground.svg
@@ -1,0 +1,3 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="120" cy="120" r="64" fill="#B4A0FF"/>
+</svg>

--- a/studio/movie-streaming-app/MovieStreamApp/Assets/Splash/splash_screen.svg
+++ b/studio/movie-streaming-app/MovieStreamApp/Assets/Splash/splash_screen.svg
@@ -1,0 +1,3 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="120" cy="120" r="64" fill="#B4A0FF"/>
+</svg>

--- a/studio/movie-streaming-app/MovieStreamApp/MovieStreamApp.csproj
+++ b/studio/movie-streaming-app/MovieStreamApp/MovieStreamApp.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-browserwasm;net10.0-desktop</TargetFrameworks>
 
@@ -36,6 +36,19 @@
       ThemeService;
       SkiaRenderer;
     </UnoFeatures>
+  </PropertyGroup>
+
+  <!--
+    App icon + splash screen via Uno.Resizetizer (all platforms). Required on Android:
+    the generated manifest references @mipmap/icon, and Resources/values/Styles.xml
+    references @drawable/uno_splash_image / @color/uno_splash_color - the resizetizer
+    only emits these resources when an icon and splash screen are declared here.
+  -->
+  <PropertyGroup>
+    <UnoIconForegroundFile>Assets/Icons/icon_foreground.svg</UnoIconForegroundFile>
+    <UnoIconBackgroundColor>#151515</UnoIconBackgroundColor>
+    <UnoSplashScreenFile>Assets/Splash/splash_screen.svg</UnoSplashScreenFile>
+    <UnoSplashScreenColor>#151515</UnoSplashScreenColor>
   </PropertyGroup>
 
 </Project>

--- a/studio/movie-streaming-app/global.json
+++ b/studio/movie-streaming-app/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "Uno.Sdk": "6.7.0-dev.50"
+    "Uno.Sdk.Private": "6.7.0-dev.850"
   },
   "sdk": {
     "allowPrerelease": false

--- a/studio/overalls-maker/DenimOverallsApp/Assets/Icons/icon.svg
+++ b/studio/overalls-maker/DenimOverallsApp/Assets/Icons/icon.svg
@@ -1,0 +1,3 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="240" height="240" fill="#151515"/>
+</svg>

--- a/studio/overalls-maker/DenimOverallsApp/Assets/Icons/icon_foreground.svg
+++ b/studio/overalls-maker/DenimOverallsApp/Assets/Icons/icon_foreground.svg
@@ -1,0 +1,3 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="120" cy="120" r="64" fill="#B4A0FF"/>
+</svg>

--- a/studio/overalls-maker/DenimOverallsApp/Assets/Splash/splash_screen.svg
+++ b/studio/overalls-maker/DenimOverallsApp/Assets/Splash/splash_screen.svg
@@ -1,0 +1,3 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="120" cy="120" r="64" fill="#B4A0FF"/>
+</svg>

--- a/studio/overalls-maker/DenimOverallsApp/DenimOverallsApp.csproj
+++ b/studio/overalls-maker/DenimOverallsApp/DenimOverallsApp.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-browserwasm;net10.0-desktop</TargetFrameworks>
 
@@ -36,6 +36,19 @@
       ThemeService;
       SkiaRenderer;
     </UnoFeatures>
+  </PropertyGroup>
+
+  <!--
+    App icon + splash screen via Uno.Resizetizer (all platforms). Required on Android:
+    the generated manifest references @mipmap/icon, and Resources/values/Styles.xml
+    references @drawable/uno_splash_image / @color/uno_splash_color - the resizetizer
+    only emits these resources when an icon and splash screen are declared here.
+  -->
+  <PropertyGroup>
+    <UnoIconForegroundFile>Assets/Icons/icon_foreground.svg</UnoIconForegroundFile>
+    <UnoIconBackgroundColor>#151515</UnoIconBackgroundColor>
+    <UnoSplashScreenFile>Assets/Splash/splash_screen.svg</UnoSplashScreenFile>
+    <UnoSplashScreenColor>#151515</UnoSplashScreenColor>
   </PropertyGroup>
 
 </Project>

--- a/studio/overalls-maker/global.json
+++ b/studio/overalls-maker/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "Uno.Sdk": "6.7.0-dev.50"
+    "Uno.Sdk.Private": "6.7.0-dev.850"
   },
   "sdk": {
     "allowPrerelease": false

--- a/studio/travel-app/Voyago/Voyago.csproj
+++ b/studio/travel-app/Voyago/Voyago.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-browserwasm;net10.0-desktop</TargetFrameworks>
 

--- a/studio/travel-app/global.json
+++ b/studio/travel-app/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "Uno.Sdk": "6.7.0-dev.50"
+    "Uno.Sdk.Private": "6.7.0-dev.850"
   },
   "sdk": {
     "allowPrerelease": false

--- a/studio/uno-crm/UnoCRM/UnoCRM.csproj
+++ b/studio/uno-crm/UnoCRM/UnoCRM.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+<Project Sdk="Uno.Sdk.Private">
   <PropertyGroup>
     <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-browserwasm;net10.0-desktop</TargetFrameworks>
 

--- a/studio/uno-crm/global.json
+++ b/studio/uno-crm/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "6.5.31"
+    "Uno.Sdk.Private": "6.7.0-dev.850"
   },
   "sdk": {
     "allowPrerelease": false


### PR DESCRIPTION
Bumps all Studio Live gallery samples from the old `Uno.Sdk` (6.7.0-dev.50, and 6.5.31 for uno-crm) to `Uno.Sdk.Private` 6.7.0-dev.850, matching the SDK Studio Live itself uses.

## Why
 The old dev.50 generator predates `UnoEnableAlcAppSupport`, so sample binaries built from it carry no per-ALC `SetResolutionContext` wrap and can pick up a previously-loaded sample's identically-named resource dictionaries. Building the samples with a current SDK makes the generated app emit the wrap itself. This is defense-in-depth alongside the host-side guard in studio.live#3197 - either one fixes the bleed; both is belt-and-suspenders.
