### PR TITLE
chore: Bump reference samples to Uno.Sdk 6.6.42

### DIFF
--- a/build/stage-build-samples.yml
+++ b/build/stage-build-samples.yml
@@ -79,6 +79,14 @@ jobs:
       # So it will be safer to remove it. For now, we set it to false as it makes the build much faster.
       dotnet build $(solutionPath) /p:AndroidAddKeepAlives=false /p:Configuration=Release /p:WasmShellMonoRuntimeExecutionMode=Interpreter /p:PublishTrimmed=false /p:WasmShellILLinkerEnabled=false /p:EnableCoreMrtTooling=false /p:RunAOTCompilation=false /p:MtouchUseLlvm=false /p:WindowsAppSDKSelfContained=false /p:WindowsPackageType=None "/bl:$(build.artifactstagingdirectory)\$(Agent.JobName).binlog"
 
+      # Capture the build result immediately: a subsequent 'dotnet test' would
+      # overwrite $LASTEXITCODE and silently mask a failed build.
+      $buildExitCode = $LASTEXITCODE
+      if ($buildExitCode -ne 0) {
+          Write-Host "##vso[task.logissue type=error]Build failed for $(solutionPath) with exit code $buildExitCode"
+          exit $buildExitCode
+      }
+
       # Locate test projects and execute tests if applicable.
       $folderPath = [System.IO.Path]::GetDirectoryName("$(solutionPath)")
       $testProject = Get-Item -Path $folderPath\**\*.Tests.csproj -ErrorAction SilentlyContinue
@@ -89,7 +97,7 @@ jobs:
           Write-Host "No tests found for project: $($folderPath)"
       }
 
-      # Ensure the build fails on error.
+      # Ensure the step fails if the tests failed.
       if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       # Configure Git to handle long paths and clean the repository to avoid disk space issues.

--- a/reference/Commerce/src/.vscode/launch.json
+++ b/reference/Commerce/src/.vscode/launch.json
@@ -26,7 +26,7 @@
       "server": {
         "runtimeExecutable": "dotnet",
         "program": "run",
-        "args": ["--no-build","-f","net9.0-browserwasm","--launch-profile", "Commerce (WebAssembly)"],
+        "args": ["--no-build","-f","net10.0-browserwasm","--launch-profile", "Commerce (WebAssembly)"],
         "outputCapture": "std",
         "timeout": 30000,
         "cwd": "${workspaceFolder}/Commerce"
@@ -41,7 +41,7 @@
       "request": "launch",
       "preLaunchTask": "build-desktop",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/Commerce/bin/Debug/net9.0-desktop/Commerce.dll",
+      "program": "${workspaceFolder}/Commerce/bin/Debug/net10.0-desktop/Commerce.dll",
       "args": [],
       "launchSettingsProfile": "Commerce (Desktop)",
       "env": {

--- a/reference/Commerce/src/.vscode/tasks.json
+++ b/reference/Commerce/src/.vscode/tasks.json
@@ -9,7 +9,7 @@
         "build",
         "${workspaceFolder}/Commerce/Commerce.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -22,7 +22,7 @@
         "publish",
         "${workspaceFolder}/Commerce/Commerce.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -35,7 +35,7 @@
         "build",
         "${workspaceFolder}/Commerce/Commerce.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -48,7 +48,7 @@
         "publish",
         "${workspaceFolder}/Commerce/Commerce.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"

--- a/reference/Commerce/src/Commerce/Commerce.csproj
+++ b/reference/Commerce/src/Commerce/Commerce.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.26100;net10.0-browserwasm;net10.0-desktop</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>

--- a/reference/Commerce/src/global.json
+++ b/reference/Commerce/src/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "6.5.29"
+    "Uno.Sdk": "6.6.42"
   },
   "sdk": {
     "allowPrerelease": false

--- a/reference/Counter/CSharp-MVUX/.vscode/launch.json
+++ b/reference/Counter/CSharp-MVUX/.vscode/launch.json
@@ -26,7 +26,7 @@
       "server": {
         "runtimeExecutable": "dotnet",
         "program": "run",
-        "args": ["--no-build","-f","net9.0-browserwasm","--launch-profile", "Counter (WebAssembly)"],
+        "args": ["--no-build","-f","net10.0-browserwasm","--launch-profile", "Counter (WebAssembly)"],
         "outputCapture": "std",
         "timeout": 30000,
         "cwd": "${workspaceFolder}/Counter"
@@ -41,7 +41,7 @@
       "request": "launch",
       "preLaunchTask": "build-desktop",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/Counter/bin/Debug/net9.0-desktop/Counter.dll",
+      "program": "${workspaceFolder}/Counter/bin/Debug/net10.0-desktop/Counter.dll",
       "args": [],
       "launchSettingsProfile": "Counter (Desktop)",
       "env": {

--- a/reference/Counter/CSharp-MVUX/.vscode/tasks.json
+++ b/reference/Counter/CSharp-MVUX/.vscode/tasks.json
@@ -9,7 +9,7 @@
         "build",
         "${workspaceFolder}/Counter/Counter.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -22,7 +22,7 @@
         "publish",
         "${workspaceFolder}/Counter/Counter.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -35,7 +35,7 @@
         "build",
         "${workspaceFolder}/Counter/Counter.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -48,7 +48,7 @@
         "publish",
         "${workspaceFolder}/Counter/Counter.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"

--- a/reference/Counter/CSharp-MVUX/Counter/Counter.csproj
+++ b/reference/Counter/CSharp-MVUX/Counter/Counter.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.26100;net10.0-browserwasm;net10.0-desktop</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>

--- a/reference/Counter/CSharp-MVUX/global.json
+++ b/reference/Counter/CSharp-MVUX/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "6.5.29"
+    "Uno.Sdk": "6.6.42"
   },
   "sdk": {
     "allowPrerelease": false

--- a/reference/Counter/CSharp-MVVM/.vscode/launch.json
+++ b/reference/Counter/CSharp-MVVM/.vscode/launch.json
@@ -26,7 +26,7 @@
       "server": {
         "runtimeExecutable": "dotnet",
         "program": "run",
-        "args": ["--no-build","-f","net9.0-browserwasm","--launch-profile", "Counter (WebAssembly)"],
+        "args": ["--no-build","-f","net10.0-browserwasm","--launch-profile", "Counter (WebAssembly)"],
         "outputCapture": "std",
         "timeout": 30000,
         "cwd": "${workspaceFolder}/Counter"
@@ -41,7 +41,7 @@
       "request": "launch",
       "preLaunchTask": "build-desktop",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/Counter/bin/Debug/net9.0-desktop/Counter.dll",
+      "program": "${workspaceFolder}/Counter/bin/Debug/net10.0-desktop/Counter.dll",
       "args": [],
       "launchSettingsProfile": "Counter (Desktop)",
       "env": {

--- a/reference/Counter/CSharp-MVVM/.vscode/tasks.json
+++ b/reference/Counter/CSharp-MVVM/.vscode/tasks.json
@@ -9,7 +9,7 @@
         "build",
         "${workspaceFolder}/Counter/Counter.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -22,7 +22,7 @@
         "publish",
         "${workspaceFolder}/Counter/Counter.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -35,7 +35,7 @@
         "build",
         "${workspaceFolder}/Counter/Counter.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -48,7 +48,7 @@
         "publish",
         "${workspaceFolder}/Counter/Counter.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"

--- a/reference/Counter/CSharp-MVVM/Counter/Counter.csproj
+++ b/reference/Counter/CSharp-MVVM/Counter/Counter.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.26100;net10.0-browserwasm;net10.0-desktop</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>

--- a/reference/Counter/CSharp-MVVM/global.json
+++ b/reference/Counter/CSharp-MVVM/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "6.5.29"
+    "Uno.Sdk": "6.6.42"
   },
   "sdk": {
     "allowPrerelease": false

--- a/reference/Counter/XAML-MVUX/.vscode/launch.json
+++ b/reference/Counter/XAML-MVUX/.vscode/launch.json
@@ -26,7 +26,7 @@
       "server": {
         "runtimeExecutable": "dotnet",
         "program": "run",
-        "args": ["--no-build","-f","net9.0-browserwasm","--launch-profile", "Counter (WebAssembly)"],
+        "args": ["--no-build","-f","net10.0-browserwasm","--launch-profile", "Counter (WebAssembly)"],
         "outputCapture": "std",
         "timeout": 30000,
         "cwd": "${workspaceFolder}/Counter"
@@ -41,7 +41,7 @@
       "request": "launch",
       "preLaunchTask": "build-desktop",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/Counter/bin/Debug/net9.0-desktop/Counter.dll",
+      "program": "${workspaceFolder}/Counter/bin/Debug/net10.0-desktop/Counter.dll",
       "args": [],
       "launchSettingsProfile": "Counter (Desktop)",
       "env": {

--- a/reference/Counter/XAML-MVUX/.vscode/tasks.json
+++ b/reference/Counter/XAML-MVUX/.vscode/tasks.json
@@ -9,7 +9,7 @@
         "build",
         "${workspaceFolder}/Counter/Counter.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -22,7 +22,7 @@
         "publish",
         "${workspaceFolder}/Counter/Counter.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -35,7 +35,7 @@
         "build",
         "${workspaceFolder}/Counter/Counter.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -48,7 +48,7 @@
         "publish",
         "${workspaceFolder}/Counter/Counter.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"

--- a/reference/Counter/XAML-MVUX/Counter/Counter.csproj
+++ b/reference/Counter/XAML-MVUX/Counter/Counter.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.26100;net10.0-browserwasm;net10.0-desktop</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>

--- a/reference/Counter/XAML-MVUX/global.json
+++ b/reference/Counter/XAML-MVUX/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "6.5.29"
+    "Uno.Sdk": "6.6.42"
   },
   "sdk": {
     "allowPrerelease": false

--- a/reference/Counter/XAML-MVVM/.vscode/launch.json
+++ b/reference/Counter/XAML-MVVM/.vscode/launch.json
@@ -26,7 +26,7 @@
       "server": {
         "runtimeExecutable": "dotnet",
         "program": "run",
-        "args": ["--no-build","-f","net9.0-browserwasm","--launch-profile", "Counter (WebAssembly)"],
+        "args": ["--no-build","-f","net10.0-browserwasm","--launch-profile", "Counter (WebAssembly)"],
         "outputCapture": "std",
         "timeout": 30000,
         "cwd": "${workspaceFolder}/Counter"
@@ -41,7 +41,7 @@
       "request": "launch",
       "preLaunchTask": "build-desktop",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/Counter/bin/Debug/net9.0-desktop/Counter.dll",
+      "program": "${workspaceFolder}/Counter/bin/Debug/net10.0-desktop/Counter.dll",
       "args": [],
       "launchSettingsProfile": "Counter (Desktop)",
       "env": {

--- a/reference/Counter/XAML-MVVM/.vscode/tasks.json
+++ b/reference/Counter/XAML-MVVM/.vscode/tasks.json
@@ -9,7 +9,7 @@
         "build",
         "${workspaceFolder}/Counter/Counter.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -22,7 +22,7 @@
         "publish",
         "${workspaceFolder}/Counter/Counter.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -35,7 +35,7 @@
         "build",
         "${workspaceFolder}/Counter/Counter.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -48,7 +48,7 @@
         "publish",
         "${workspaceFolder}/Counter/Counter.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"

--- a/reference/Counter/XAML-MVVM/Counter/Counter.csproj
+++ b/reference/Counter/XAML-MVVM/Counter/Counter.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.26100;net10.0-browserwasm;net10.0-desktop</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>

--- a/reference/Counter/XAML-MVVM/global.json
+++ b/reference/Counter/XAML-MVVM/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "6.5.29"
+    "Uno.Sdk": "6.6.42"
   },
   "sdk": {
     "allowPrerelease": false

--- a/reference/SimpleCalc/CSharp-MVUX/.vscode/launch.json
+++ b/reference/SimpleCalc/CSharp-MVUX/.vscode/launch.json
@@ -26,7 +26,7 @@
       "server": {
         "runtimeExecutable": "dotnet",
         "program": "run",
-        "args": ["--no-build","-f","net9.0-browserwasm","--launch-profile", "SimpleCalculator (WebAssembly)"],
+        "args": ["--no-build","-f","net10.0-browserwasm","--launch-profile", "SimpleCalculator (WebAssembly)"],
         "outputCapture": "std",
         "timeout": 30000,
         "cwd": "${workspaceFolder}/SimpleCalculator"
@@ -41,7 +41,7 @@
       "request": "launch",
       "preLaunchTask": "build-desktop",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/SimpleCalculator/bin/Debug/net9.0-desktop/SimpleCalculator.dll",
+      "program": "${workspaceFolder}/SimpleCalculator/bin/Debug/net10.0-desktop/SimpleCalculator.dll",
       "args": [],
       "launchSettingsProfile": "SimpleCalculator (Desktop)",
       "env": {

--- a/reference/SimpleCalc/CSharp-MVUX/.vscode/tasks.json
+++ b/reference/SimpleCalc/CSharp-MVUX/.vscode/tasks.json
@@ -9,7 +9,7 @@
         "build",
         "${workspaceFolder}/SimpleCalculator/SimpleCalculator.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -22,7 +22,7 @@
         "publish",
         "${workspaceFolder}/SimpleCalculator/SimpleCalculator.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -35,7 +35,7 @@
         "build",
         "${workspaceFolder}/SimpleCalculator/SimpleCalculator.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -48,7 +48,7 @@
         "publish",
         "${workspaceFolder}/SimpleCalculator/SimpleCalculator.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"

--- a/reference/SimpleCalc/CSharp-MVUX/SimpleCalculator.Tests/SimpleCalculator.Tests.csproj
+++ b/reference/SimpleCalc/CSharp-MVUX/SimpleCalculator.Tests/SimpleCalculator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/reference/SimpleCalc/CSharp-MVUX/SimpleCalculator/SimpleCalculator.csproj
+++ b/reference/SimpleCalc/CSharp-MVUX/SimpleCalculator/SimpleCalculator.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.26100;net10.0-browserwasm;net10.0-desktop;net10.0</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>

--- a/reference/SimpleCalc/CSharp-MVUX/global.json
+++ b/reference/SimpleCalc/CSharp-MVUX/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "6.5.29"
+    "Uno.Sdk": "6.6.42"
   },
   "sdk": {
     "allowPrerelease": false

--- a/reference/SimpleCalc/CSharp-MVVM/.vscode/launch.json
+++ b/reference/SimpleCalc/CSharp-MVVM/.vscode/launch.json
@@ -26,7 +26,7 @@
       "server": {
         "runtimeExecutable": "dotnet",
         "program": "run",
-        "args": ["--no-build","-f","net9.0-browserwasm","--launch-profile", "SimpleCalculator (WebAssembly)"],
+        "args": ["--no-build","-f","net10.0-browserwasm","--launch-profile", "SimpleCalculator (WebAssembly)"],
         "outputCapture": "std",
         "timeout": 30000,
         "cwd": "${workspaceFolder}/SimpleCalculator"
@@ -41,7 +41,7 @@
       "request": "launch",
       "preLaunchTask": "build-desktop",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/SimpleCalculator/bin/Debug/net9.0-desktop/SimpleCalculator.dll",
+      "program": "${workspaceFolder}/SimpleCalculator/bin/Debug/net10.0-desktop/SimpleCalculator.dll",
       "args": [],
       "launchSettingsProfile": "SimpleCalculator (Desktop)",
       "env": {

--- a/reference/SimpleCalc/CSharp-MVVM/.vscode/tasks.json
+++ b/reference/SimpleCalc/CSharp-MVVM/.vscode/tasks.json
@@ -9,7 +9,7 @@
         "build",
         "${workspaceFolder}/SimpleCalculator/SimpleCalculator.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -22,7 +22,7 @@
         "publish",
         "${workspaceFolder}/SimpleCalculator/SimpleCalculator.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -35,7 +35,7 @@
         "build",
         "${workspaceFolder}/SimpleCalculator/SimpleCalculator.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -48,7 +48,7 @@
         "publish",
         "${workspaceFolder}/SimpleCalculator/SimpleCalculator.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"

--- a/reference/SimpleCalc/CSharp-MVVM/SimpleCalculator.Tests/SimpleCalculator.Tests.csproj
+++ b/reference/SimpleCalc/CSharp-MVVM/SimpleCalculator.Tests/SimpleCalculator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/reference/SimpleCalc/CSharp-MVVM/SimpleCalculator/SimpleCalculator.csproj
+++ b/reference/SimpleCalc/CSharp-MVVM/SimpleCalculator/SimpleCalculator.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.26100;net10.0-browserwasm;net10.0-desktop;net10.0</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>

--- a/reference/SimpleCalc/CSharp-MVVM/global.json
+++ b/reference/SimpleCalc/CSharp-MVVM/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "6.5.29"
+    "Uno.Sdk": "6.6.42"
   },
   "sdk": {
     "allowPrerelease": false

--- a/reference/SimpleCalc/XAML-MVUX/.vscode/launch.json
+++ b/reference/SimpleCalc/XAML-MVUX/.vscode/launch.json
@@ -26,7 +26,7 @@
       "server": {
         "runtimeExecutable": "dotnet",
         "program": "run",
-        "args": ["--no-build","-f","net9.0-browserwasm","--launch-profile", "SimpleCalculator (WebAssembly)"],
+        "args": ["--no-build","-f","net10.0-browserwasm","--launch-profile", "SimpleCalculator (WebAssembly)"],
         "outputCapture": "std",
         "timeout": 30000,
         "cwd": "${workspaceFolder}/SimpleCalculator"
@@ -41,7 +41,7 @@
       "request": "launch",
       "preLaunchTask": "build-desktop",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/SimpleCalculator/bin/Debug/net9.0-desktop/SimpleCalculator.dll",
+      "program": "${workspaceFolder}/SimpleCalculator/bin/Debug/net10.0-desktop/SimpleCalculator.dll",
       "args": [],
       "launchSettingsProfile": "SimpleCalculator (Desktop)",
       "env": {

--- a/reference/SimpleCalc/XAML-MVUX/.vscode/tasks.json
+++ b/reference/SimpleCalc/XAML-MVUX/.vscode/tasks.json
@@ -9,7 +9,7 @@
         "build",
         "${workspaceFolder}/SimpleCalculator/SimpleCalculator.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -22,7 +22,7 @@
         "publish",
         "${workspaceFolder}/SimpleCalculator/SimpleCalculator.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -35,7 +35,7 @@
         "build",
         "${workspaceFolder}/SimpleCalculator/SimpleCalculator.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -48,7 +48,7 @@
         "publish",
         "${workspaceFolder}/SimpleCalculator/SimpleCalculator.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"

--- a/reference/SimpleCalc/XAML-MVUX/SimpleCalculator-XAML-MVUX.sln
+++ b/reference/SimpleCalc/XAML-MVUX/SimpleCalculator-XAML-MVUX.sln
@@ -13,7 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		global.json = global.json
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleCalculator.Tests", "..\CSharp-MVVM\SimpleCalculator.Tests\SimpleCalculator.Tests.csproj", "{642A08BF-808E-4258-BC66-B1CD014BBE90}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleCalculator.Tests", "SimpleCalculator.Tests\SimpleCalculator.Tests.csproj", "{642A08BF-808E-4258-BC66-B1CD014BBE90}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/reference/SimpleCalc/XAML-MVUX/SimpleCalculator.Tests/SimpleCalculator.Tests.csproj
+++ b/reference/SimpleCalc/XAML-MVUX/SimpleCalculator.Tests/SimpleCalculator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/reference/SimpleCalc/XAML-MVUX/SimpleCalculator/SimpleCalculator.csproj
+++ b/reference/SimpleCalc/XAML-MVUX/SimpleCalculator/SimpleCalculator.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.26100;net10.0-browserwasm;net10.0-desktop;net10.0</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>

--- a/reference/SimpleCalc/XAML-MVUX/global.json
+++ b/reference/SimpleCalc/XAML-MVUX/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "6.5.29"
+    "Uno.Sdk": "6.6.42"
   },
   "sdk": {
     "allowPrerelease": false

--- a/reference/SimpleCalc/XAML-MVVM/.vscode/launch.json
+++ b/reference/SimpleCalc/XAML-MVVM/.vscode/launch.json
@@ -26,7 +26,7 @@
       "server": {
         "runtimeExecutable": "dotnet",
         "program": "run",
-        "args": ["--no-build","-f","net9.0-browserwasm","--launch-profile", "SimpleCalculator (WebAssembly)"],
+        "args": ["--no-build","-f","net10.0-browserwasm","--launch-profile", "SimpleCalculator (WebAssembly)"],
         "outputCapture": "std",
         "timeout": 30000,
         "cwd": "${workspaceFolder}/SimpleCalculator"
@@ -41,7 +41,7 @@
       "request": "launch",
       "preLaunchTask": "build-desktop",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/SimpleCalculator/bin/Debug/net9.0-desktop/SimpleCalculator.dll",
+      "program": "${workspaceFolder}/SimpleCalculator/bin/Debug/net10.0-desktop/SimpleCalculator.dll",
       "args": [],
       "launchSettingsProfile": "SimpleCalculator (Desktop)",
       "env": {

--- a/reference/SimpleCalc/XAML-MVVM/.vscode/tasks.json
+++ b/reference/SimpleCalc/XAML-MVVM/.vscode/tasks.json
@@ -9,7 +9,7 @@
         "build",
         "${workspaceFolder}/SimpleCalculator/SimpleCalculator.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -22,7 +22,7 @@
         "publish",
         "${workspaceFolder}/SimpleCalculator/SimpleCalculator.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -35,7 +35,7 @@
         "build",
         "${workspaceFolder}/SimpleCalculator/SimpleCalculator.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -48,7 +48,7 @@
         "publish",
         "${workspaceFolder}/SimpleCalculator/SimpleCalculator.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"

--- a/reference/SimpleCalc/XAML-MVVM/SimpleCalculator-XAML-MVVM.sln
+++ b/reference/SimpleCalc/XAML-MVVM/SimpleCalculator-XAML-MVVM.sln
@@ -13,7 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		global.json = global.json
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleCalculator.Tests", "..\CSharp-MVVM\SimpleCalculator.Tests\SimpleCalculator.Tests.csproj", "{6CF23882-DFE5-48E6-AC2F-4B0BFDC68FEF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleCalculator.Tests", "SimpleCalculator.Tests\SimpleCalculator.Tests.csproj", "{6CF23882-DFE5-48E6-AC2F-4B0BFDC68FEF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/reference/SimpleCalc/XAML-MVVM/SimpleCalculator.Tests/SimpleCalculator.Tests.csproj
+++ b/reference/SimpleCalc/XAML-MVVM/SimpleCalculator.Tests/SimpleCalculator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/reference/SimpleCalc/XAML-MVVM/SimpleCalculator/SimpleCalculator.csproj
+++ b/reference/SimpleCalc/XAML-MVVM/SimpleCalculator/SimpleCalculator.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop;net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.26100;net10.0-browserwasm;net10.0-desktop;net10.0</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>

--- a/reference/SimpleCalc/XAML-MVVM/global.json
+++ b/reference/SimpleCalc/XAML-MVVM/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "6.5.29"
+    "Uno.Sdk": "6.6.42"
   },
   "sdk": {
     "allowPrerelease": false

--- a/reference/ToDo/src/.vscode/launch.json
+++ b/reference/ToDo/src/.vscode/launch.json
@@ -26,7 +26,7 @@
       "server": {
         "runtimeExecutable": "dotnet",
         "program": "run",
-        "args": ["--no-build","-f","net9.0-browserwasm","--launch-profile", "ToDo (WebAssembly)"],
+        "args": ["--no-build","-f","net10.0-browserwasm","--launch-profile", "ToDo (WebAssembly)"],
         "outputCapture": "std",
         "timeout": 30000,
         "cwd": "${workspaceFolder}/ToDo"
@@ -41,7 +41,7 @@
       "request": "launch",
       "preLaunchTask": "build-desktop",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/ToDo/bin/Debug/net9.0-desktop/ToDo.dll",
+      "program": "${workspaceFolder}/ToDo/bin/Debug/net10.0-desktop/ToDo.dll",
       "args": [],
       "launchSettingsProfile": "ToDo (Desktop)",
       "env": {

--- a/reference/ToDo/src/.vscode/tasks.json
+++ b/reference/ToDo/src/.vscode/tasks.json
@@ -9,7 +9,7 @@
         "build",
         "${workspaceFolder}/ToDo/ToDo.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -22,7 +22,7 @@
         "publish",
         "${workspaceFolder}/ToDo/ToDo.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -35,7 +35,7 @@
         "build",
         "${workspaceFolder}/ToDo/ToDo.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -48,7 +48,7 @@
         "publish",
         "${workspaceFolder}/ToDo/ToDo.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"

--- a/reference/ToDo/src/ToDo/GlobalUsings.cs
+++ b/reference/ToDo/src/ToDo/GlobalUsings.cs
@@ -44,3 +44,10 @@ global using Windows.Security.Authentication.Web;
 global using System;
 global using System.Collections.Generic;
 global using Uno.Extensions.Navigation;
+
+// Pins the MVUX bindable generator to v2, which is the version this sample's
+// naming convention targets (models named *ViewModel produce Bindable*ViewModel).
+// The implicit default became v3 in Uno.Extensions.Reactive 7.2.3, and v3 derives
+// names as Name.TrimEnd("Model") + "ViewModel" — turning SettingsViewModel into
+// SettingsViewViewModel. Migrating to v3 means renaming the models to *Model.
+[assembly: Uno.Extensions.Reactive.Config.BindableGenerationTool(2)]

--- a/reference/ToDo/src/ToDo/GlobalUsings.cs
+++ b/reference/ToDo/src/ToDo/GlobalUsings.cs
@@ -45,9 +45,10 @@ global using System;
 global using System.Collections.Generic;
 global using Uno.Extensions.Navigation;
 
-// Pins the MVUX bindable generator to v2, which is the version this sample's
-// naming convention targets (models named *ViewModel produce Bindable*ViewModel).
-// The implicit default became v3 in Uno.Extensions.Reactive 7.2.3, and v3 derives
-// names as Name.TrimEnd("Model") + "ViewModel" — turning SettingsViewModel into
-// SettingsViewViewModel. Migrating to v3 means renaming the models to *Model.
+// Pins the MVUX bindable generator to v2, which matches this sample's naming
+// convention: a model named SettingsViewModel generates BindableSettingsViewModel.
+// Uno.Extensions.Reactive 7.2.3 made v3 the default instead. v3 strips a trailing
+// "Model" from the model's name and appends "ViewModel", so SettingsViewModel would
+// generate SettingsViewViewModel and BindableSettingsViewModel would no longer
+// exist. Moving to v3 means renaming the models here from *ViewModel to *Model.
 [assembly: Uno.Extensions.Reactive.Config.BindableGenerationTool(2)]

--- a/reference/ToDo/src/ToDo/ToDo.csproj
+++ b/reference/ToDo/src/ToDo/ToDo.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-windows10.0.26100;net9.0-browserwasm</TargetFrameworks>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-windows10.0.26100;net10.0-browserwasm</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>

--- a/reference/ToDo/src/global.json
+++ b/reference/ToDo/src/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "6.5.29"
+    "Uno.Sdk": "6.6.42"
   },
   "sdk": {
     "allowPrerelease": false

--- a/reference/TubePlayer/src/.vscode/launch.json
+++ b/reference/TubePlayer/src/.vscode/launch.json
@@ -26,7 +26,7 @@
       "server": {
         "runtimeExecutable": "dotnet",
         "program": "run",
-        "args": ["--no-build","-f","net9.0-browserwasm","--launch-profile", "TubePlayer (WebAssembly)"],
+        "args": ["--no-build","-f","net10.0-browserwasm","--launch-profile", "TubePlayer (WebAssembly)"],
         "outputCapture": "std",
         "timeout": 30000,
         "cwd": "${workspaceFolder}/TubePlayer"
@@ -41,7 +41,7 @@
       "request": "launch",
       "preLaunchTask": "build-desktop",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/TubePlayer/bin/Debug/net9.0-desktop/TubePlayer.dll",
+      "program": "${workspaceFolder}/TubePlayer/bin/Debug/net10.0-desktop/TubePlayer.dll",
       "args": [],
       "launchSettingsProfile": "TubePlayer (Desktop)",
       "env": {

--- a/reference/TubePlayer/src/.vscode/tasks.json
+++ b/reference/TubePlayer/src/.vscode/tasks.json
@@ -9,7 +9,7 @@
         "build",
         "${workspaceFolder}/TubePlayer/TubePlayer.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -22,7 +22,7 @@
         "publish",
         "${workspaceFolder}/TubePlayer/TubePlayer.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-browserwasm",
+        "/property:TargetFramework=net10.0-browserwasm",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -35,7 +35,7 @@
         "build",
         "${workspaceFolder}/TubePlayer/TubePlayer.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"
@@ -48,7 +48,7 @@
         "publish",
         "${workspaceFolder}/TubePlayer/TubePlayer.csproj",
         "/property:GenerateFullPaths=true",
-        "/property:TargetFramework=net9.0-desktop",
+        "/property:TargetFramework=net10.0-desktop",
         "/consoleloggerparameters:NoSummary"
       ],
       "problemMatcher": "$msCompile"

--- a/reference/TubePlayer/src/TubePlayer/TubePlayer.csproj
+++ b/reference/TubePlayer/src/TubePlayer/TubePlayer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Uno.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-windows10.0.26100;net9.0-browserwasm;net9.0-desktop</TargetFrameworks>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.26100;net10.0-browserwasm;net10.0-desktop</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <UnoSingleProject>true</UnoSingleProject>

--- a/reference/TubePlayer/src/global.json
+++ b/reference/TubePlayer/src/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "6.5.29"
+    "Uno.Sdk": "6.6.42"
   },
   "sdk": {
     "allowPrerelease": false


### PR DESCRIPTION
**GitHub Issue:** Related to https://github.com/unoplatform/private/issues/1082 and https://github.com/unoplatform/private/issues/1092

## PR Type

- 🏗️ Build or CI related changes
- 🐞 Bugfix (two fixes were needed to make this land green — see below)

## What is the current behavior?

All 11 reference sample solutions pin `Uno.Sdk` **6.5.29** and target **`net9.0-*`**.

On CI they are also **all failing**, and four of them fail *silently* (details below).

## What is the new behavior?

All 11 pin **`Uno.Sdk` 6.6.42** — the 6.6 SR2 stable release (core 6.6.184, Uno.Extensions 7.2.3, Themes 7.0.3, Toolkit 9.0.3, Fonts 2.9.4) — and target **`net10.0-*`**.

| Sample | Solution folder |
|---|---|
| Commerce | `reference/Commerce/src` |
| Counter | `reference/Counter/{CSharp-MVUX, CSharp-MVVM, XAML-MVUX, XAML-MVVM}` |
| SimpleCalc | `reference/SimpleCalc/{CSharp-MVUX, CSharp-MVVM, XAML-MVUX, XAML-MVVM}` |
| ToDo | `reference/ToDo/src` |
| TubePlayer | `reference/TubePlayer/src` |

### .NET 10 migration

Per [How to Upgrade from .NET 9 to .NET 10](https://platform.uno/docs/articles/migrating-from-net9-to-net10.html), the migration is TFM references plus a `bin`/`obj` clean. This PR retargets:

- the 11 app projects (`net9.0-android;net9.0-ios;…` → `net10.0-*`),
- the 4 `SimpleCalculator.Tests` projects (`net9.0` → `net10.0`),
- the per-sample `.vscode/launch.json` and `tasks.json`, which name TFMs explicitly in build args and `bin/Debug/<tfm>/` program paths.

**No pipeline change is needed for net10 itself** — `build/templates/dotnet-install-windows.yml` already installs the `10.0.x` SDK and runs `uno-check` to provision the workloads.

## Why CI was red — and why .NET 10 is the fix

Every sample was failing on the WebAssembly head:

```
error UNOWA0001: Native WebAssembly assets were detected, but the wasm-tools
workload could not be located. … 'dotnet workload install wasm-tools-net9'
[Counter.csproj::TargetFramework=net9.0-browserwasm]
```

The workload step on the agents installs `android ios maccatalyst tvos maui wasm-tools`, where `wasm-tools` is the **net10** flavour (`.NET WebAssembly build tools for net10.0`, manifest `Microsoft.NET.Workload.Mono.ToolChain.Manifest-10.0.100`). **`wasm-tools-net9` is never installed**, so any sample with native WASM assets cannot build `net9.0-browserwasm` on CI.

Retargeting to `net10.0-browserwasm` puts the samples on the workload the agents actually provide, which is what makes this pipeline green rather than a pipeline-side workaround.

## Second fix: CI was reporting false greens

While diagnosing the above, the four SimpleCalculator jobs reported **success** even though their logs contain the identical `UNOWA0001` error:

```
line 38:  Build FAILED.                          ← 1 Error(s): UNOWA0001
line 65:  Passed! - Failed: 0, Passed: 8         ← dotnet test then succeeded
line 71:  if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
```

The `Build Sample` step ran `dotnet build`, then `dotnet test`, then checked `$LASTEXITCODE` **once at the very end**. For the only four solutions that have a `.Tests` project, the successful `dotnet test` overwrote the failed build's exit code, so the job exited 0. The seven samples without test projects failed correctly — which is exactly why the failure looked partial instead of universal.

`build/stage-build-samples.yml` now captures the build's exit code immediately, fails fast, and logs a `task.logissue` so it shows in the run summary. This is a pre-existing bug independent of the version bump, but it directly undermines this PR's own signal, so it is fixed here.

## Third fix: MVUX bindable generator default changed

`ToDo` failed to compile on 6.6.42 with:

```
Views/Dialogs/SettingsFlyout.xaml.cs(21,39): error CS0246:
The type or namespace name 'BindableSettingsViewModel' could not be found
```

Uno.Extensions 7.2 changes the default MVUX bindable generation tool from **v2** to **v3**, which renames the generated type:

| Tool | `SettingsViewModel` generates |
|---|---|
| v2 | `BindableSettingsViewModel` |
| v3 | `SettingsViewViewModel` |

v3 expects models named `SettingsModel` so the generated type lands on `SettingsViewModel`. `ToDo` names its models `*ViewModel`, and is the only reference sample that references a generated bindable type **by name** in C# — and the only MVUX sample without an explicit tool version (Counter and SimpleCalc MVUX variants and TubePlayer all already pin `(3)` in `GlobalUsings.cs`).

Per the [6.6 migration notes](https://platform.uno/docs/articles/migrating-from-previous-releases.html), the documented way to keep the previous generator is an assembly-level pin, which is what this PR does:

```csharp
[assembly: Uno.Extensions.Reactive.Config.BindableGenerationTool(2)]
```

This reproduces exactly the code `ToDo` already compiled on 6.5.29, keeping this PR a bump rather than a refactor. Note v3 also improves Hot Reload support, so migrating `ToDo` to v3 — renaming its models `*ViewModel` → `*Model` and updating the XAML `x:DataType` and navigation registrations — is worth a dedicated follow-up PR with runtime validation.

## Fourth fix: two XAML SimpleCalc solutions referenced the wrong test project

`SimpleCalculator-XAML-MVUX.sln` and `SimpleCalculator-XAML-MVVM.sln` both referenced `..\CSharp-MVVM\SimpleCalculator.Tests\SimpleCalculator.Tests.csproj` instead of the `SimpleCalculator.Tests` project sitting next to them — which exists in both folders.

That pulled the **CSharp-MVVM app project** into the XAML solutions transitively (via the test project's `ProjectReference`), where it failed:

```
CSharp-MVVM\SimpleCalculator\App.xaml.cs(33,20): error CS1061:
'Window' does not contain a definition for 'UseStudio'
[SimpleCalculator.csproj::TargetFramework=net10.0]
```

Both solutions now point at their own test project. This is pre-existing and unrelated to the version bump — those solutions were already broken this way, but the exit-code masking described above hid it, so it only became visible once that was fixed.

## Uno Themes 7.0 / Uno Toolkit 9.0 audit

6.6.42 moves Themes 6.1 → 7.0 and Toolkit 8.4 → 9.0. Audited against the 6.6 migration notes:

| Item | Result |
|---|---|
| `MaterialToolkitResourcesV1` / `V2` (fails at startup) | ✅ not used |
| Generated dictionary URIs losing the `WinUI` suffix (`mergedpages.*`) | ✅ no URI merges |
| `<MaterialTheme />` alongside `MaterialToolkitTheme` (double init) | ✅ none; the C# samples use the `MaterialToolkitTheme(colorOverride, fontOverride)` ctor |
| `BaseTheme.GenerateSpecificResources()` removed | ✅ not used |
| UWP-flavored `Uno.Toolkit.UI` / `.Material` packages | ✅ not referenced |
| Explicit Themes/Toolkit version pins | ✅ none — all implicit via `Uno.Sdk` |
| `ColorOverrideSource` deprecated | ⚠️ used by 4 samples — see below |

`Commerce`, `SimpleCalc/XAML-MVUX`, `SimpleCalc/XAML-MVVM` and `ToDo` set `ColorOverrideSource`, now superseded by `Colors` / `ThemeColors.OverrideSource`. The Uno Themes migration guide states the legacy properties "**still work — they write through to the corresponding `Colors` members internally**", with unchanged precedence. Since the failure mode of getting that XAML wrong is at *runtime* (resource-not-found) rather than build time, a green build would not prove it, so it is intentionally left for a follow-up rather than changed blind in a version-bump PR.

## Validation

Local (Windows, .NET SDK 10.0.301), all `-c Release`, on `net10.0` after a full `bin`/`obj` clean:

| Sample | `net10.0-desktop` | `net10.0-browserwasm` |
|---|---|---|
| Commerce | ✅ | ✅ |
| Counter × 4 | ✅ ✅ ✅ ✅ | ✅ ✅ ✅ ✅ |
| SimpleCalc × 4 | ✅ ✅ ✅ ✅ | ✅ ✅ ✅ ✅ |
| ToDo | n/a¹ | ✅ |
| TubePlayer | ✅ | ✅ |

¹ `ToDo` declares no `-desktop` TFM (`android;ios;windows10.0.26100;browserwasm`) — pre-existing, unrelated to this PR.

- **Restore:** 11/11 clean on net10 across every declared TFM. No `NU1605` downgrades, no resolution failures.
- **Test projects:** all 4 `SimpleCalculator.Tests` build clean on `net10.0`.
- **`ToDo` extra coverage** (it carries the MVUX fix and has no desktop head): clean on `net10.0-browserwasm`, and clean on `net9.0-android` + `net9.0-windows10.0.26100` when the fix was validated pre-retarget. Warning count and build time matched the 6.5.29 baseline exactly (9 warnings, ~54s WASM), confirming the generated code is unchanged from pre-bump.
- **Fixed XAML solutions:** both `SimpleCalculator-XAML-MVUX.sln` and `-XAML-MVVM.sln` build clean (`0 Error(s)`) across **all six TFMs** using the same command and properties the pipeline uses.
- iOS and macCatalyst had no local coverage (no macOS build host) — they are covered by CI below.

### CI progression

| Job | Before (net9) | After net10 retarget | After `.sln` fix |
|---|---|---|---|
| Commerce | ❌ `UNOWA0001` | ✅ | ✅ |
| Counter × 4 | ❌ `UNOWA0001` | ✅ ✅ ✅ ✅ | ✅ ✅ ✅ ✅ |
| ToDo | ❌ `UNOWA0001` | ✅ | ✅ |
| TubePlayer | ❌ `UNOWA0001` | ✅ | ✅ |
| SimpleCalculator-CSharp-MVUX | ⚠️ false green | ✅ | ✅ |
| SimpleCalculator-CSharp-MVVM | ⚠️ false green | ✅ | ✅ |
| SimpleCalculator-XAML-MVUX | ⚠️ false green | ❌ `CS1061` | ✅ |
| SimpleCalculator-XAML-MVVM | ⚠️ false green | ❌ `CS1061` | ✅ |

**Final CI state: 11/11 green, no failures.**

"⚠️ false green" = the job reported success while its log contained `Build FAILED`, per the exit-code masking fixed here — so the "Before" column reflects that **every** sample was in fact failing, not just the seven that reported it.

The net10 retarget cleared `UNOWA0001` on all seven genuinely-red jobs. The two remaining failures were the wrong-test-project `.sln` bug, correlating exactly with the two affected solutions, and both now pass. Every job is green under the stricter exit-code handling, so this is a real green rather than a masked one.

## PR Checklist ✅

- [x] 📝 Commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
- [x] ✅ Builds validated locally on Desktop and WebAssembly for every sample, plus Android/Windows for `ToDo`.
- [x] 🧪 Existing `SimpleCalculator.Tests` projects retargeted and building.
- [x] 🚫 Contains **NO** breaking changes to sample behavior.

## Other information

Package pins in `Directory.Packages.props`/csproj are untouched: these samples take their Uno package versions implicitly from `Uno.Sdk`, so `global.json` is the only version surface.

The `UI/` samples are **not** touched here — they range from 5.1.50 to 6.5.31, with most on 5.3/5.4, so bringing them forward is a considerably larger effort best handled separately.
