### PR TITLE
refactor(todo): migrate MVUX bindable generation tool from v2 to v3

### DIFF
--- a/reference/ToDo/README.md
+++ b/reference/ToDo/README.md
@@ -14,12 +14,12 @@ In addition, the sample code utilizes [Uno.Extensions](https://aka.platform.uno/
 
 ## Codebase
 
-* [**WelcomeViewModel.cs**](src/ToDo/Presentation/WelcomeViewModel.cs) accessing tokens with Authentication.
-* [**TaskListViewModel.cs**](src/ToDo/Presentation/TaskListViewModel.cs) common Navigation methods.
-* [**HomeViewModel.cs**](src/ToDo/Presentation/HomeViewModel.cs) changing the language with Localization via the model.
+* [**WelcomeModel.cs**](src/ToDo/Presentation/WelcomeModel.cs) accessing tokens with Authentication.
+* [**TaskListModel.cs**](src/ToDo/Presentation/TaskListModel.cs) common Navigation methods.
+* [**HomeModel.cs**](src/ToDo/Presentation/HomeModel.cs) changing the language with Localization via the model.
 * [**TaskListPage.xaml**](src/ToDo/Views/TaskListPage.xaml) adapting the language in the Xaml with Localization via `x:Uid`.
-* [**SettingsViewModel.cs**](src/ToDo/Presentation/SettingsViewModel.cs) theme switching with ThemeService.
-* [**TaskListViewModel.cs**](src/ToDo/Presentation/TaskListViewModel.cs) Reactive ListFeeds with [**TaskListPage.xaml**](src/ToDo/Views/TaskListPage.xaml) FeedViews.
+* [**SettingsModel.cs**](src/ToDo/Presentation/SettingsModel.cs) theme switching with ThemeService.
+* [**TaskListModel.cs**](src/ToDo/Presentation/TaskListModel.cs) Reactive ListFeeds with [**TaskListPage.xaml**](src/ToDo/Views/TaskListPage.xaml) FeedViews.
 
 
 ## What is the Uno Platform

--- a/reference/ToDo/src/ToDo/App.xaml.cs
+++ b/reference/ToDo/src/ToDo/App.xaml.cs
@@ -96,45 +96,45 @@ public partial class App : Application
 
         views.Register(
             // Dialogs and Flyouts
-            new ViewMap<AddTaskFlyout, AddTaskViewModel>(),
-            new ViewMap<AddListFlyout, AddListViewModel>(),
-            new ViewMap<ExpirationDateFlyout, ExpirationDateViewModel>(Data: new DataMap<PickedDate>()),
-            new ViewMap<RenameListFlyout, RenameListViewModel>(),
+            new ViewMap<AddTaskFlyout, AddTaskModel>(),
+            new ViewMap<AddListFlyout, AddListModel>(),
+            new ViewMap<ExpirationDateFlyout, ExpirationDateModel>(Data: new DataMap<PickedDate>()),
+            new ViewMap<RenameListFlyout, RenameListModel>(),
 
             // Views
-            new ViewMap<HomePage, HomeViewModel>(),
+            new ViewMap<HomePage, HomeModel>(),
             new ViewMap<TaskSearchFlyout>(),
-            new ViewMap<SearchPage, SearchViewModel>(),
-            new ViewMap<SettingsFlyout, SettingsViewModel>(),
-            new ViewMap<Shell, ShellViewModel>(),
-            new ViewMap<WelcomePage, WelcomeViewModel>(),
-            new DataViewMap<TaskListPage, TaskListViewModel, TaskList>(),
-            new DataViewMap<TaskPage, TaskViewModel, ToDoTask>(),
+            new ViewMap<SearchPage, SearchModel>(),
+            new ViewMap<SettingsFlyout, SettingsModel>(),
+            new ViewMap<Shell, ShellModel>(),
+            new ViewMap<WelcomePage, WelcomeModel>(),
+            new DataViewMap<TaskListPage, TaskListModel, TaskList>(),
+            new DataViewMap<TaskPage, TaskModel, ToDoTask>(),
             confirmDeleteListDialog,
             confirmDeleteTaskDialog,
             confirmSignOutDialog
         );
 
         routes.Register(
-            new RouteMap("", View: views.FindByViewModel<ShellViewModel>(), Nested: new RouteMap[]
+            new RouteMap("", View: views.FindByViewModel<ShellModel>(), Nested: new RouteMap[]
             {
-                new("Welcome", View: views.FindByViewModel<WelcomeViewModel>()),
-                new("Home", View: views.FindByViewModel<HomeViewModel>()),
-                new("TaskList", View: views.FindByViewModel<TaskListViewModel>(), Nested: new[]
+                new("Welcome", View: views.FindByViewModel<WelcomeModel>()),
+                new("Home", View: views.FindByViewModel<HomeModel>()),
+                new("TaskList", View: views.FindByViewModel<TaskListModel>(), Nested: new[]
                 {
                     new RouteMap("ToDo", IsDefault:true),
                     new RouteMap("Completed")
                 }),
-                new("Task", View: views.FindByViewModel<TaskViewModel>(), DependsOn:"TaskList"),
+                new("Task", View: views.FindByViewModel<TaskModel>(), DependsOn:"TaskList"),
                 new("TaskSearch", View: views.FindByView<TaskSearchFlyout>(), Nested: new RouteMap[]
                 {
-                    new("Search", View: views.FindByViewModel<SearchViewModel>(), IsDefault: true)
+                    new("Search", View: views.FindByViewModel<SearchModel>(), IsDefault: true)
                 }),
-                new("Settings", View: views.FindByViewModel<SettingsViewModel>()),
-                new("AddTask", View: views.FindByViewModel<AddTaskViewModel>()),
-                new("AddList", View: views.FindByViewModel<AddListViewModel>()),
-                new("ExpirationDate", View: views.FindByViewModel<ExpirationDateViewModel>()),
-                new("RenameList", View: views.FindByViewModel<RenameListViewModel>()),
+                new("Settings", View: views.FindByViewModel<SettingsModel>()),
+                new("AddTask", View: views.FindByViewModel<AddTaskModel>()),
+                new("AddList", View: views.FindByViewModel<AddListModel>()),
+                new("ExpirationDate", View: views.FindByViewModel<ExpirationDateModel>()),
+                new("RenameList", View: views.FindByViewModel<RenameListModel>()),
                 new(Dialog.ConfirmDeleteList, confirmDeleteListDialog),
                 new(Dialog.ConfirmDeleteTask, confirmDeleteTaskDialog),
                 new(Dialog.ConfirmSignOut, confirmSignOutDialog)

--- a/reference/ToDo/src/ToDo/GlobalUsings.cs
+++ b/reference/ToDo/src/ToDo/GlobalUsings.cs
@@ -45,10 +45,4 @@ global using System;
 global using System.Collections.Generic;
 global using Uno.Extensions.Navigation;
 
-// Pins the MVUX bindable generator to v2, which matches this sample's naming
-// convention: a model named SettingsViewModel generates BindableSettingsViewModel.
-// Uno.Extensions.Reactive 7.2.3 made v3 the default instead. v3 strips a trailing
-// "Model" from the model's name and appends "ViewModel", so SettingsViewModel would
-// generate SettingsViewViewModel and BindableSettingsViewModel would no longer
-// exist. Moving to v3 means renaming the models here from *ViewModel to *Model.
-[assembly: Uno.Extensions.Reactive.Config.BindableGenerationTool(2)]
+[assembly: Uno.Extensions.Reactive.Config.BindableGenerationTool(3)]

--- a/reference/ToDo/src/ToDo/Presentation/Dialogs/AddListModel.cs
+++ b/reference/ToDo/src/ToDo/Presentation/Dialogs/AddListModel.cs
@@ -1,5 +1,5 @@
 namespace ToDo.Presentation.Dialogs;
 
-public partial class AddTaskViewModel
+public partial class AddListModel
 {
 }

--- a/reference/ToDo/src/ToDo/Presentation/Dialogs/AddTaskModel.cs
+++ b/reference/ToDo/src/ToDo/Presentation/Dialogs/AddTaskModel.cs
@@ -1,5 +1,5 @@
 namespace ToDo.Presentation.Dialogs;
 
-public partial class AddListViewModel
+public partial class AddTaskModel
 {
 }

--- a/reference/ToDo/src/ToDo/Presentation/Dialogs/ExpirationDateModel.cs
+++ b/reference/ToDo/src/ToDo/Presentation/Dialogs/ExpirationDateModel.cs
@@ -2,11 +2,11 @@ namespace ToDo.Presentation.Dialogs;
 
 public partial record PickedDate(DateTimeOffset? Date);
 
-public partial class ExpirationDateViewModel
+public partial class ExpirationDateModel
 {
 	private readonly INavigator _navigator;
 
-	private ExpirationDateViewModel(INavigator navigator, PickedDate entity)
+	private ExpirationDateModel(INavigator navigator, PickedDate entity)
 	{
 		_navigator = navigator;
 

--- a/reference/ToDo/src/ToDo/Presentation/Dialogs/RenameListModel.cs
+++ b/reference/ToDo/src/ToDo/Presentation/Dialogs/RenameListModel.cs
@@ -1,0 +1,3 @@
+namespace ToDo.Presentation.Dialogs;
+
+public partial record  RenameListModel(TaskList Entity);

--- a/reference/ToDo/src/ToDo/Presentation/Dialogs/RenameListModel.cs
+++ b/reference/ToDo/src/ToDo/Presentation/Dialogs/RenameListModel.cs
@@ -1,3 +1,3 @@
 namespace ToDo.Presentation.Dialogs;
 
-public partial record  RenameListModel(TaskList Entity);
+public partial record RenameListModel(TaskList Entity);

--- a/reference/ToDo/src/ToDo/Presentation/Dialogs/RenameListViewModel.cs
+++ b/reference/ToDo/src/ToDo/Presentation/Dialogs/RenameListViewModel.cs
@@ -1,3 +1,0 @@
-namespace ToDo.Presentation.Dialogs;
-
-public partial record  RenameListViewModel(TaskList Entity);

--- a/reference/ToDo/src/ToDo/Presentation/HomeModel.cs
+++ b/reference/ToDo/src/ToDo/Presentation/HomeModel.cs
@@ -2,7 +2,7 @@ using IAuthenticationService = ToDo.Business.IAuthenticationService;
 
 namespace ToDo.Presentation;
 
-public partial class HomeViewModel
+public partial class HomeModel
 {
 	private readonly INavigator _navigator;
 	private readonly IAuthenticationService _authSvc;
@@ -11,7 +11,7 @@ public partial class HomeViewModel
 	private readonly ITaskListService _listSvc;
 	private readonly IWritableOptions<ToDoApp> _appSettings;
 
-	public HomeViewModel(
+	public HomeModel(
 		INavigator navigator,
 		IStringLocalizer localizer,
 		IAuthenticationService authSvc,
@@ -62,7 +62,7 @@ public partial class HomeViewModel
 
 	public async ValueTask CreateTaskList(CancellationToken ct)
 	{
-		var listName = await _navigator.GetDataAsync<AddListViewModel, string>(this, qualifier: Qualifiers.Dialog, cancellation: ct);
+		var listName = await _navigator.GetDataAsync<AddListModel, string>(this, qualifier: Qualifiers.Dialog, cancellation: ct);
 
 		if (listName is not null)
 		{

--- a/reference/ToDo/src/ToDo/Presentation/SearchModel.cs
+++ b/reference/ToDo/src/ToDo/Presentation/SearchModel.cs
@@ -1,10 +1,10 @@
 ﻿namespace ToDo.Presentation;
 
-public partial class SearchViewModel
+public partial class SearchModel
 {
 	private readonly ITaskService _svc;
 
-	public SearchViewModel(ITaskService svc)
+	public SearchModel(ITaskService svc)
 	{
 		_svc = svc;
 	}

--- a/reference/ToDo/src/ToDo/Presentation/SettingsModel.cs
+++ b/reference/ToDo/src/ToDo/Presentation/SettingsModel.cs
@@ -3,7 +3,7 @@ using IAuthenticationService = ToDo.Business.IAuthenticationService;
 
 namespace ToDo.Presentation;
 
-public partial class SettingsViewModel
+public partial class SettingsModel
 {
     private readonly IAuthenticationService _authService;
     private readonly IUserProfilePictureService _userSvc;
@@ -19,7 +19,7 @@ public partial class SettingsViewModel
 
     public string[] AppThemes { get; }
 
-    public SettingsViewModel(
+    public SettingsModel(
         NavigationRequest request,
         INavigator navigator,
         IAuthenticationService authService,
@@ -67,7 +67,7 @@ public partial class SettingsViewModel
         {
             await _authService.SignOutAsync();
 
-            await _sourceNavigator.NavigateViewModelAsync<HomeViewModel>(this);
+            await _sourceNavigator.NavigateViewModelAsync<HomeModel>(this);
         }
     }
 

--- a/reference/ToDo/src/ToDo/Presentation/ShellModel.cs
+++ b/reference/ToDo/src/ToDo/Presentation/ShellModel.cs
@@ -1,11 +1,11 @@
 namespace ToDo.Presentation;
 
-public class ShellViewModel
+public class ShellModel
 {
     private readonly INavigator _navigator;
     private readonly IAuthenticationTokenProvider _auth;
 
-    public ShellViewModel(
+    public ShellModel(
         INavigator navigator,
         IAuthenticationTokenProvider authentication)
     {
@@ -20,11 +20,11 @@ public class ShellViewModel
         var token = await _auth.GetAccessToken();
         if (string.IsNullOrWhiteSpace(token))
         {
-            await _navigator.NavigateViewModelAsync<WelcomeViewModel>(this);
+            await _navigator.NavigateViewModelAsync<WelcomeModel>(this);
         }
         else
         {
-            await _navigator.NavigateViewModelAsync<HomeViewModel>(this);
+            await _navigator.NavigateViewModelAsync<HomeModel>(this);
         }
     }
 }

--- a/reference/ToDo/src/ToDo/Presentation/TaskListModel.cs
+++ b/reference/ToDo/src/ToDo/Presentation/TaskListModel.cs
@@ -2,15 +2,15 @@ using Dialog = ToDo.Presentation.Dialogs.Dialog;
 
 namespace ToDo.Presentation;
 
-public partial class TaskListViewModel
+public partial class TaskListModel
 {
     private readonly INavigator _navigator;
     private readonly ITaskListService _listSvc;
     private readonly ITaskService _taskSvc;
     private readonly ILogger _logger;
 
-    public TaskListViewModel(
-        ILogger<TaskListViewModel> logger,
+    public TaskListModel(
+        ILogger<TaskListModel> logger,
         INavigator navigator,
         ITaskListService listSvc,
         ITaskService taskSvc,
@@ -51,7 +51,7 @@ public partial class TaskListViewModel
             return;
         }
 
-        var taskName = await _navigator.GetDataAsync<AddTaskViewModel, string>(this, qualifier: Qualifiers.Dialog, cancellation: ct);
+        var taskName = await _navigator.GetDataAsync<AddTaskModel, string>(this, qualifier: Qualifiers.Dialog, cancellation: ct);
         if (taskName is { Length: > 0 })
         {
             var newTask = new ToDoTask { Title = taskName };
@@ -83,7 +83,7 @@ public partial class TaskListViewModel
             return;
         }
 
-        var result = await _navigator.NavigateViewModelForResultAsync<RenameListViewModel, string>(this, qualifier: Qualifiers.Dialog, data: list, cancellation: ct).AsResult();
+        var result = await _navigator.NavigateViewModelForResultAsync<RenameListModel, string>(this, qualifier: Qualifiers.Dialog, data: list, cancellation: ct).AsResult();
         if (result.IsSome(out var newListName) && !string.IsNullOrWhiteSpace(newListName))
         {
             list = list with { DisplayName = newListName };

--- a/reference/ToDo/src/ToDo/Presentation/TaskModel.cs
+++ b/reference/ToDo/src/ToDo/Presentation/TaskModel.cs
@@ -2,12 +2,12 @@
 
 namespace ToDo.Presentation;
 
-public partial class TaskViewModel
+public partial class TaskModel
 {
     private readonly INavigator _navigator;
     private readonly ITaskService _svc;
 
-    public TaskViewModel(
+    public TaskModel(
         INavigator navigator,
         ITaskService svc,
         ToDoTask entity)
@@ -76,7 +76,7 @@ public partial class TaskViewModel
         }
 
         var result = await _navigator
-            .NavigateViewModelForResultAsync<ExpirationDateViewModel, PickedDate>(this, qualifier: Qualifiers.Dialog, data: new PickedDate(task.DueDateTime), cancellation: ct)
+            .NavigateViewModelForResultAsync<ExpirationDateModel, PickedDate>(this, qualifier: Qualifiers.Dialog, data: new PickedDate(task.DueDateTime), cancellation: ct)
             .AsResult();
 
         if (result.SomeOrDefault()?.Date is { } date)

--- a/reference/ToDo/src/ToDo/Presentation/WelcomeModel.cs
+++ b/reference/ToDo/src/ToDo/Presentation/WelcomeModel.cs
@@ -3,13 +3,13 @@ using IAuthenticationService = ToDo.Business.IAuthenticationService;
 
 namespace ToDo.Presentation;
 
-public partial class WelcomeViewModel
+public partial class WelcomeModel
 {
 	private readonly IAuthenticationService _authService;
 	private readonly INavigator _navigator;
 	private readonly IDispatcher _dispatcher;
 
-	public WelcomeViewModel(
+	public WelcomeModel(
 		IDispatcher dispatcher,
 		INavigator navigator,
 		IAuthenticationService authService)

--- a/reference/ToDo/src/ToDo/Views/Dialogs/SettingsFlyout.xaml.cs
+++ b/reference/ToDo/src/ToDo/Views/Dialogs/SettingsFlyout.xaml.cs
@@ -18,7 +18,7 @@ public sealed partial class SettingsFlyout : Flyout, IRecipient<ThemeChangedMess
 
     private void ThemeChipGroup_ItemChecked(object sender, ChipItemEventArgs e)
     {
-        if (FlyoutRoot.DataContext is BindableSettingsViewModel viewModel)
+        if (FlyoutRoot.DataContext is SettingsViewModel viewModel)
         {
 #if ANDROID
             if (_isThemeInitialized)


### PR DESCRIPTION
Follow-up to #941, as discussed in https://github.com/unoplatform/Uno.Samples/pull/941#discussion_r3730472758 (option A: keep the v2 pin in the bump PR, migrate to v3 in a follow-up).

## PR Type

- 🔄 Refactoring (no functional changes)

## What is the current behavior?

`ToDo` is the only MVUX reference sample still on bindable generation tool **v2**, pinned via `[assembly: BindableGenerationTool(2)]` in `GlobalUsings.cs`. Its models are named `*ViewModel` and `SettingsFlyout.xaml.cs` references the v2-generated `BindableSettingsViewModel`.

## What is the new behavior?

`ToDo` now uses generator **v3**, matching every other MVUX sample in the repo:

- Renamed the 11 presentation models from `*ViewModel` to `*Model` (files and classes), so v3 generates the `*ViewModel` types (e.g. `SettingsModel` → generated `SettingsViewModel`).
- Updated all `ViewMap`/`RouteMap` registrations in `App.xaml.cs` and the cross-model navigation generics (`NavigateViewModelAsync<T>`, `GetDataAsync<T,...>`, etc.).
- `SettingsFlyout.xaml.cs` now casts the DataContext to the v3-generated `SettingsViewModel` instead of `BindableSettingsViewModel`.
- Replaced the v2 pin with `[assembly: Uno.Extensions.Reactive.Config.BindableGenerationTool(3)]`, the same form the 14 other samples use.
- Updated `README.md` codebase links to the renamed files.

Entity records (`TaskList`, `ToDoTask`, `PickedDate`, …) are unaffected: v3 only generates ViewModels for partial types with a `Model` suffix, so no naming collisions.

## Validation

- `dotnet build ToDo/ToDo.csproj -f net10.0-windows10.0.26100` — build succeeded, 0 errors.
- ToDo has no XAML `x:DataType` or compiled-binding references to model type names; all binding goes through the navigation-provided DataContext.
- Validated at runtime on the Windows head: page navigation and the settings flyout (theme switching) work as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
