### PR TITLE
feat(samples): add MSAL auth sample using Uno.Extensions.Authentication.MSAL

### DIFF
--- a/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/App.xaml
+++ b/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/App.xaml
@@ -1,0 +1,15 @@
+<Application x:Class="Authentication.MsalExtensionsDemo.App"
+       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+  <Application.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+      </ResourceDictionary.MergedDictionaries>
+
+      <FontFamily x:Key="CodeFontFamily">Menlo, Consolas, Courier New, monospace</FontFamily>
+    </ResourceDictionary>
+  </Application.Resources>
+
+</Application>

--- a/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/App.xaml.cs
+++ b/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/App.xaml.cs
@@ -28,8 +28,7 @@ public partial class App : Application
                     .UseConfiguration(configure: configBuilder => configBuilder
                         .EmbeddedSource<App>())
                     .UseAuthentication(auth => auth
-                        .AddMsal(window, msal => msal
-                            .Builder(ConfigurePlatformRedirect)))
+                        .AddMsal(window))
                     .ConfigureServices(services => services
                         .AddSingleton<IDispatcher>(new Dispatcher(window))));
 
@@ -65,20 +64,6 @@ public partial class App : Application
         var origin = WebAuthenticationBroker.GetCurrentApplicationCallbackUri().GetLeftPart(UriPartial.Authority);
         Uno.WinRTFeatureConfiguration.WebAuthenticationBroker.DefaultReturnUri =
             new Uri($"{origin}{MsalConfig.WasmRedirectPath}");
-    }
-
-    private static void ConfigurePlatformRedirect(PublicClientApplicationBuilder builder)
-    {
-#if ANDROID
-        builder.WithRedirectUri($"{MsalConfig.AndroidRedirectScheme}://auth");
-#elif IOS
-        builder.WithRedirectUri(MsalConfig.IosRedirectUri);
-#else
-        if (!PlatformHelper.IsWebAssembly)
-        {
-            builder.WithRedirectUri(MsalConfig.DesktopRedirectUri);
-        }
-#endif
     }
 
     public static void InitializeLogging()

--- a/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/App.xaml.cs
+++ b/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/App.xaml.cs
@@ -1,0 +1,87 @@
+using Uno.Resizetizer;
+using Windows.Security.Authentication.Web;
+
+namespace Authentication.MsalExtensionsDemo;
+
+public partial class App : Application
+{
+    public App()
+    {
+        this.InitializeComponent();
+    }
+
+    public static IHost? AppHost { get; private set; }
+
+    protected Window? MainWindow { get; private set; }
+
+    protected override async void OnLaunched(LaunchActivatedEventArgs args)
+    {
+        try
+        {
+            ConfigureWasmRedirect();
+
+            var builder = this.CreateBuilder(args)
+                .Configure((host, window) => host
+                    .UseLogging(configure: (context, logBuilder) => logBuilder
+                        .SetMinimumLevel(LogLevel.Information)
+                        .AddFilter("Uno.Extensions.Authentication", LogLevel.Trace))
+                    .UseConfiguration(configure: configBuilder => configBuilder
+                        .EmbeddedSource<App>())
+                    .UseAuthentication(auth => auth
+                        .AddMsal(window, msal => msal
+                            .Builder(ConfigurePlatformRedirect)))
+                    .ConfigureServices(services => services
+                        .AddSingleton<IDispatcher>(new Dispatcher(window))));
+
+            MainWindow = builder.Window;
+#if DEBUG
+            MainWindow.UseStudio();
+#endif
+
+            AppHost = builder.Build();
+            await AppHost.StartAsync();
+
+            if (MainWindow.Content is null)
+            {
+                MainWindow.Content = new MainPage();
+            }
+
+            MainWindow.SetWindowIcon();
+            MainWindow.Activate();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"App launch failed: {ex}");
+        }
+    }
+
+    private static void ConfigureWasmRedirect()
+    {
+        if (!PlatformHelper.IsWebAssembly)
+        {
+            return;
+        }
+
+        var origin = WebAuthenticationBroker.GetCurrentApplicationCallbackUri().GetLeftPart(UriPartial.Authority);
+        Uno.WinRTFeatureConfiguration.WebAuthenticationBroker.DefaultReturnUri =
+            new Uri($"{origin}{MsalConfig.WasmRedirectPath}");
+    }
+
+    private static void ConfigurePlatformRedirect(PublicClientApplicationBuilder builder)
+    {
+#if ANDROID
+        builder.WithRedirectUri($"{MsalConfig.AndroidRedirectScheme}://auth");
+#elif IOS
+        builder.WithRedirectUri(MsalConfig.IosRedirectUri);
+#else
+        if (!PlatformHelper.IsWebAssembly)
+        {
+            builder.WithRedirectUri(MsalConfig.DesktopRedirectUri);
+        }
+#endif
+    }
+
+    public static void InitializeLogging()
+    {
+    }
+}

--- a/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo.csproj
+++ b/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Uno.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-browserwasm;net10.0-desktop</TargetFrameworks>
+
+    <OutputType>Exe</OutputType>
+    <UnoSingleProject>true</UnoSingleProject>
+
+    <ApplicationTitle>Authentication.MsalExtensionsDemo</ApplicationTitle>
+    <ApplicationId>com.companyname.authentication.msalextensionsdemo</ApplicationId>
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+    <ApplicationVersion>1</ApplicationVersion>
+    <ApplicationPublisher>Authentication.MsalExtensionsDemo</ApplicationPublisher>
+    <Description>MSAL via Uno.Extensions.Authentication.MSAL.</Description>
+
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <UnoFeatures>
+      SkiaRenderer;
+      Hosting;
+      Configuration;
+      Logging;
+      AuthenticationMsal;
+    </UnoFeatures>
+
+    <NoWarn>$(NoWarn);IL2007;NETSDK1201;PRI257</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/Authentication/MsalConfig.cs
+++ b/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/Authentication/MsalConfig.cs
@@ -1,0 +1,14 @@
+namespace Authentication.MsalExtensionsDemo.Authentication;
+
+internal static class MsalConfig
+{
+    public const string ClientId = "00000000-0000-0000-0000-000000000000";
+
+    public const string AndroidRedirectScheme = "msal" + ClientId;
+
+    public const string IosRedirectUri = "msauth.com.companyname.authentication.msalextensionsdemo://auth";
+
+    public const string DesktopRedirectUri = "http://localhost";
+
+    public const string WasmRedirectPath = "/authentication/login-callback.htm";
+}

--- a/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/GlobalUsings.cs
+++ b/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/GlobalUsings.cs
@@ -1,0 +1,10 @@
+global using Authentication.MsalExtensionsDemo.Authentication;
+global using Microsoft.Extensions.DependencyInjection;
+global using Microsoft.Extensions.Hosting;
+global using Microsoft.Extensions.Logging;
+global using Microsoft.Identity.Client;
+global using Uno.Extensions;
+global using Uno.Extensions.Authentication;
+global using Uno.Extensions.Configuration;
+global using Uno.Extensions.Hosting;
+global using LogLevel = Microsoft.Extensions.Logging.LogLevel;

--- a/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/MainPage.xaml
+++ b/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/MainPage.xaml
@@ -1,0 +1,51 @@
+<Page x:Class="Authentication.MsalExtensionsDemo.MainPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+  <Grid Padding="20" RowSpacing="12">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="*" />
+    </Grid.RowDefinitions>
+
+    <StackPanel Spacing="4">
+      <TextBlock Text="MSAL via Uno.Extensions.Authentication"
+                 Style="{StaticResource TitleTextBlockStyle}" />
+      <TextBlock x:Name="StatusText"
+                 Text="Starting..."
+                 Style="{StaticResource BodyStrongTextBlockStyle}" />
+    </StackPanel>
+
+    <StackPanel Grid.Row="1"
+                Orientation="Horizontal"
+                Spacing="8">
+      <Button x:Name="SignInButton" Content="Sign in" Click="OnSignIn" />
+      <Button Content="Silent refresh" Click="OnRefresh" />
+      <Button Content="Sign out" Click="OnSignOut" />
+      <Button Content="Cache state" Click="OnCacheState" />
+    </StackPanel>
+
+    <TextBlock Grid.Row="2"
+               x:Name="TokenText"
+               FontFamily="{StaticResource CodeFontFamily}"
+               FontSize="12"
+               IsTextSelectionEnabled="True"
+               TextWrapping="Wrap" />
+
+    <ScrollViewer Grid.Row="3"
+                  x:Name="LogScroll"
+                  BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                  BorderThickness="1"
+                  CornerRadius="4"
+                  Padding="8">
+      <TextBlock x:Name="LogText"
+                 FontFamily="{StaticResource CodeFontFamily}"
+                 FontSize="12"
+                 IsTextSelectionEnabled="True"
+                 TextWrapping="Wrap" />
+    </ScrollViewer>
+  </Grid>
+</Page>

--- a/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/MainPage.xaml.cs
+++ b/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/MainPage.xaml.cs
@@ -1,0 +1,142 @@
+using Windows.Security.Authentication.Web;
+using ITokenCache = Uno.Extensions.Authentication.ITokenCache;
+
+namespace Authentication.MsalExtensionsDemo;
+
+public sealed partial class MainPage : Page
+{
+    private static IHost Host => App.AppHost ?? throw new InvalidOperationException("Host not built");
+
+    private IAuthenticationService Auth => Host.Services.GetRequiredService<IAuthenticationService>();
+    private IDispatcher AppDispatcher => Host.Services.GetRequiredService<IDispatcher>();
+    private ITokenCache TokenCache => Host.Services.GetRequiredService<ITokenCache>();
+
+    public MainPage()
+    {
+        this.InitializeComponent();
+        Loaded += OnLoaded;
+    }
+
+    private async void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            Log($"Providers: {string.Join(", ", Auth.Providers)}");
+            LogRedirectInfo();
+
+            var authenticated = await Auth.IsAuthenticated();
+            SetStatus(authenticated);
+            Log($"IsAuthenticated at startup: {authenticated}");
+            await ShowTokensAsync();
+        }
+        catch (Exception ex)
+        {
+            LogError("Startup check failed", ex);
+        }
+    }
+
+    private async void OnSignIn(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            Log("LoginAsync ...");
+            var ok = await Auth.LoginAsync(AppDispatcher);
+            SetStatus(ok);
+            Log($"LoginAsync -> {ok}");
+            await ShowTokensAsync();
+        }
+        catch (Exception ex)
+        {
+            LogError("LoginAsync threw", ex);
+        }
+    }
+
+    private async void OnRefresh(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            Log("RefreshAsync (silent) ...");
+            var ok = await Auth.RefreshAsync();
+            SetStatus(ok);
+            Log($"RefreshAsync -> {ok}");
+            await ShowTokensAsync();
+        }
+        catch (Exception ex)
+        {
+            LogError("RefreshAsync threw", ex);
+        }
+    }
+
+    private async void OnSignOut(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            Log("LogoutAsync ...");
+            var ok = await Auth.LogoutAsync(AppDispatcher);
+            SetStatus(authenticated: !ok && await Auth.IsAuthenticated());
+            Log($"LogoutAsync -> {ok}");
+            await ShowTokensAsync();
+        }
+        catch (Exception ex)
+        {
+            LogError("LogoutAsync threw", ex);
+        }
+    }
+
+    private async void OnCacheState(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await ShowTokensAsync();
+        }
+        catch (Exception ex)
+        {
+            LogError("Reading token cache failed", ex);
+        }
+    }
+
+    private async Task ShowTokensAsync()
+    {
+        var tokens = await TokenCache.GetAsync(CancellationToken.None);
+        if (tokens.Count == 0)
+        {
+            TokenText.Text = "Token cache: empty";
+            return;
+        }
+
+        var summary = string.Join(
+            Environment.NewLine,
+            tokens.Select(pair => $"{pair.Key}: {pair.Value.Length} chars"));
+        TokenText.Text = $"Token cache ({tokens.Count} entries):{Environment.NewLine}{summary}";
+    }
+
+    private void LogRedirectInfo()
+    {
+        if (PlatformHelper.IsWebAssembly)
+        {
+            Log($"WASM redirect URI: {WebAuthenticationBroker.GetCurrentApplicationCallbackUri()}");
+        }
+        else
+        {
+#if ANDROID
+            Log($"Redirect URI: {MsalConfig.AndroidRedirectScheme}://auth");
+#elif IOS
+            Log($"Redirect URI: {MsalConfig.IosRedirectUri}");
+#else
+            Log($"Redirect URI: {MsalConfig.DesktopRedirectUri} (loopback, any port)");
+#endif
+        }
+    }
+
+    private void SetStatus(bool authenticated) =>
+        StatusText.Text = authenticated ? "Signed in" : "Not signed in";
+
+    private void Log(string message)
+    {
+        LogText.Text += $"[{DateTime.Now:HH:mm:ss}] {message}{Environment.NewLine}";
+        LogScroll.ChangeView(null, LogScroll.ScrollableHeight, null, disableAnimation: true);
+    }
+
+    private void LogError(string context, Exception ex) =>
+        Log($"{context}: {ex.GetType().Name}: {ex.Message}");
+}

--- a/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/Platforms/Android/Main.Android.cs
+++ b/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/Platforms/Android/Main.Android.cs
@@ -1,0 +1,30 @@
+using System;
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using Microsoft.UI.Xaml.Media;
+
+namespace Authentication.MsalExtensionsDemo.Droid;
+
+[global::Android.App.ApplicationAttribute(
+    Label = "@string/ApplicationName",
+    Icon = "@mipmap/icon",
+    LargeHeap = true,
+    HardwareAccelerated = true,
+    Theme = "@style/Theme.App.Starting"
+)]
+public class Application : Microsoft.UI.Xaml.NativeApplication
+{
+    static Application()
+    {
+        App.InitializeLogging();
+    }
+
+    public Application(IntPtr javaReference, JniHandleOwnership transfer)
+        : base(() => new App(), javaReference, transfer)
+    {
+    }
+}

--- a/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/Platforms/Android/MainActivity.Android.cs
+++ b/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/Platforms/Android/MainActivity.Android.cs
@@ -1,0 +1,30 @@
+using Android.App;
+using Android.Content;
+using Android.Content.PM;
+using Android.OS;
+using Android.Views;
+using Android.Widget;
+using Microsoft.Identity.Client;
+
+namespace Authentication.MsalExtensionsDemo.Droid;
+
+[Activity(
+    MainLauncher = true,
+    ConfigurationChanges = global::Uno.UI.ActivityHelper.AllConfigChanges,
+    WindowSoftInputMode = SoftInput.AdjustNothing | SoftInput.StateHidden,
+    Exported = true
+)]
+public class MainActivity : Microsoft.UI.Xaml.ApplicationActivity
+{
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+        global::AndroidX.Core.SplashScreen.SplashScreen.InstallSplashScreen(this);
+        base.OnCreate(savedInstanceState);
+    }
+
+    protected override void OnActivityResult(int requestCode, Result resultCode, Intent? data)
+    {
+        base.OnActivityResult(requestCode, resultCode, data);
+        AuthenticationContinuationHelper.SetAuthenticationContinuationEventArgs(requestCode, resultCode, data);
+    }
+}

--- a/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/Platforms/Android/MsalActivity.Android.cs
+++ b/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/Platforms/Android/MsalActivity.Android.cs
@@ -1,0 +1,20 @@
+using Android.App;
+using Android.Content;
+using Android.Content.PM;
+using Microsoft.Identity.Client;
+
+namespace Authentication.MsalExtensionsDemo.Droid;
+
+[Activity(
+    Exported = true,
+    LaunchMode = LaunchMode.SingleTask,
+    NoHistory = true,
+    ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
+[IntentFilter(
+    [Intent.ActionView],
+    Categories = [Intent.CategoryBrowsable, Intent.CategoryDefault],
+    DataScheme = Authentication.MsalExtensionsDemo.Authentication.MsalConfig.AndroidRedirectScheme,
+    DataHost = "auth")]
+public class MsalActivity : BrowserTabActivity
+{
+}

--- a/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/Platforms/Desktop/Program.cs
+++ b/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/Platforms/Desktop/Program.cs
@@ -1,0 +1,22 @@
+using Uno.UI.Hosting;
+
+namespace Authentication.MsalExtensionsDemo;
+
+internal class Program
+{
+    [STAThread]
+    public static void Main(string[] args)
+    {
+        App.InitializeLogging();
+
+        var host = UnoPlatformHostBuilder.Create()
+            .App(() => new App())
+            .UseX11()
+            .UseLinuxFrameBuffer()
+            .UseMacOS()
+            .UseWin32()
+            .Build();
+
+        host.Run();
+    }
+}

--- a/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/Platforms/WebAssembly/Program.cs
+++ b/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/Platforms/WebAssembly/Program.cs
@@ -1,0 +1,18 @@
+using Uno.UI.Hosting;
+
+namespace Authentication.MsalExtensionsDemo;
+
+public class Program
+{
+    public static async Task Main(string[] args)
+    {
+        App.InitializeLogging();
+
+        var host = UnoPlatformHostBuilder.Create()
+            .App(() => new App())
+            .UseWebAssembly()
+            .Build();
+
+        await host.RunAsync();
+    }
+}

--- a/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/Platforms/iOS/Main.iOS.cs
+++ b/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/Platforms/iOS/Main.iOS.cs
@@ -1,0 +1,19 @@
+using UIKit;
+using Uno.UI.Hosting;
+
+namespace Authentication.MsalExtensionsDemo.iOS;
+
+public class EntryPoint
+{
+    public static void Main(string[] args)
+    {
+        App.InitializeLogging();
+
+        var host = UnoPlatformHostBuilder.Create()
+            .App(() => new App())
+            .UseAppleUIKit(builder => builder.UseUIApplicationDelegate<MsalAppDelegate>())
+            .Build();
+
+        host.Run();
+    }
+}

--- a/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/Platforms/iOS/MsalAppDelegate.iOS.cs
+++ b/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/Platforms/iOS/MsalAppDelegate.iOS.cs
@@ -1,0 +1,20 @@
+using Foundation;
+using Microsoft.Identity.Client;
+using UIKit;
+
+namespace Authentication.MsalExtensionsDemo.iOS;
+
+public class MsalAppDelegate : Uno.UI.Runtime.Skia.AppleUIKit.UnoUIApplicationDelegate
+{
+#pragma warning disable CA1422
+    public override bool OpenUrl(UIApplication application, NSUrl url, NSDictionary options)
+    {
+        if (AuthenticationContinuationHelper.SetAuthenticationContinuationEventArgs(url))
+        {
+            return true;
+        }
+
+        return base.OpenUrl(application, url, options);
+    }
+#pragma warning restore CA1422
+}

--- a/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/appsettings.json
+++ b/UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/appsettings.json
@@ -1,0 +1,7 @@
+{
+  "Msal": {
+    "ClientId": "00000000-0000-0000-0000-000000000000",
+    "TenantId": "common",
+    "Scopes": [ "https://graph.microsoft.com/User.Read" ]
+  }
+}

--- a/UI/Authentication.MsalExtensionsDemo/Directory.Build.props
+++ b/UI/Authentication.MsalExtensionsDemo/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+
+    <NoWarn>$(NoWarn);NU1507;NETSDK1201;PRI257</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/UI/Authentication.MsalExtensionsDemo/Directory.Packages.props
+++ b/UI/Authentication.MsalExtensionsDemo/Directory.Packages.props
@@ -1,0 +1,6 @@
+<Project ToolsVersion="15.0">
+  <ItemGroup>
+    <PackageVersion Include="Uno.WinUI.MSAL" Version="$(UnoVersion)" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.87.0" />
+  </ItemGroup>
+</Project>

--- a/UI/Authentication.MsalExtensionsDemo/MSAL-SETUP.md
+++ b/UI/Authentication.MsalExtensionsDemo/MSAL-SETUP.md
@@ -9,7 +9,7 @@ Use the same client ID in both places:
 - `Authentication.MsalExtensionsDemo/Authentication/MsalConfig.cs`
 - `Authentication.MsalExtensionsDemo/appsettings.json`
 
-The sample ships with a placeholder value so the app can run and explain what is missing without failing silently.
+The sample ships with a placeholder value so the app can run and explain what is missing without failing silently. This sample targets the `Uno.Sdk` 6.8.0-dev line, where the Skia runtime-asset fix for `.WithUnoHelpers()` is present.
 
 ## Redirect URIs by platform
 

--- a/UI/Authentication.MsalExtensionsDemo/MSAL-SETUP.md
+++ b/UI/Authentication.MsalExtensionsDemo/MSAL-SETUP.md
@@ -1,0 +1,40 @@
+# MSAL setup for Uno.Extensions.Authentication.MSAL
+
+## Register the app in Microsoft Entra ID
+
+Create a new public client application (desktop/mobile) in Microsoft Entra ID and grant the delegated `User.Read` permission.
+
+Use the same client ID in both places:
+
+- `Authentication.MsalExtensionsDemo/Authentication/MsalConfig.cs`
+- `Authentication.MsalExtensionsDemo/appsettings.json`
+
+The sample ships with a placeholder value so the app can run and explain what is missing without failing silently.
+
+## Redirect URIs by platform
+
+| Platform | Redirect URI |
+| --- | --- |
+| Desktop | `http://localhost` |
+| Android | `msal{ClientId}://auth` |
+| iOS | `msauth.com.companyname.authentication.msalextensionsdemo://auth` |
+| WebAssembly | `http://localhost:5000/authentication/login-callback.htm` |
+
+The app prints the exact redirect URI it is using at runtime. Register the value shown in the UI for the target you are launching.
+
+## Notes
+
+- Desktop uses the system browser and loopback listener.
+- Android uses the custom-tab flow and needs the `msal{ClientId}://auth` intent filter.
+- WebAssembly must be registered as a single-page application redirect.
+- The app logs `Uno.Extensions.Authentication` traces at `Trace` level so the sign-in and cache setup path remains visible.
+
+## Troubleshooting
+
+If interactive sign-in fails, check the following:
+
+- the client ID is correct in the app and in Entra
+- the redirect URI matches the platform you are testing
+- the app is built for the same runtime identifier you deploy
+- the log output is showing the provider trace messages from `Uno.Extensions.Authentication`
+

--- a/UI/Authentication.MsalExtensionsDemo/MSAL-SETUP.md
+++ b/UI/Authentication.MsalExtensionsDemo/MSAL-SETUP.md
@@ -20,7 +20,7 @@ The sample ships with a placeholder value so the app can run and explain what is
 | iOS | `msauth.com.companyname.authentication.msalextensionsdemo://auth` |
 | WebAssembly | `http://localhost:5000/authentication/login-callback.htm` |
 
-The app prints the exact redirect URI it is using at runtime. Register the value shown in the UI for the target you are launching.
+The app prints the exact redirect URI it is using at runtime. Register the value shown in the UI for the target you are launching. On the latest Uno.Extensions bits, the provider derives the default Android/iOS/desktop redirect automatically; this sample only overrides the WebAssembly callback page because the browser needs a fixed SPA return URI.
 
 ## Notes
 

--- a/UI/Authentication.MsalExtensionsDemo/README.md
+++ b/UI/Authentication.MsalExtensionsDemo/README.md
@@ -2,7 +2,7 @@
 
 This sample demonstrates how to sign users in with `Uno.Extensions.Authentication.MSAL` and then use the resulting access token against Microsoft Graph.
 
-It wires the Uno extensions host builder with `UseAuthentication(auth => auth.AddMsal(...))` so the provider setup and token-cache lifecycle stay in the host, while the app logic remains intentionally small and portable.
+It targets the `Uno.Sdk` 6.8.0-dev line, where the Skia MSAL fix is in place and `.WithUnoHelpers()` is no longer the no-op it was before the runtime asset fix. The provider is wired through the Uno Extensions host with `UseAuthentication(auth => auth.AddMsal(...))`, so the provider setup and token-cache lifecycle stay in the host while the app logic remains intentionally small and portable.
 
 ## What it shows
 

--- a/UI/Authentication.MsalExtensionsDemo/README.md
+++ b/UI/Authentication.MsalExtensionsDemo/README.md
@@ -22,4 +22,6 @@ See [MSAL-SETUP.md](MSAL-SETUP.md) for the complete platform matrix and troubles
 
 ## Notes
 
-This sample deliberately keeps the app logic thin and uses the default Uno.Extensions host configuration. The actual provider integration is the point of the sample: MSAL sign-in is configured with the extensions pipeline and the token cache is consumed through `IAuthenticationService` and `ITokenCache`.
+This sample deliberately keeps the app logic thin and uses the default Uno.Extensions host configuration. The provider derives the platform redirect URI automatically on the latest 6.8.0-dev bits, so the app does not need a custom `Builder(...)` redirect override; the only app-specific override is the WebAssembly callback path used by `WebAuthenticationBroker`.
+
+The actual provider integration is the point of the sample: MSAL sign-in is configured with the extensions pipeline and the token cache is consumed through `IAuthenticationService` and `ITokenCache`.

--- a/UI/Authentication.MsalExtensionsDemo/README.md
+++ b/UI/Authentication.MsalExtensionsDemo/README.md
@@ -1,0 +1,25 @@
+# Authentication with MSAL via Uno.Extensions.Authentication.MSAL
+
+This sample demonstrates how to sign users in with `Uno.Extensions.Authentication.MSAL` and then use the resulting access token against Microsoft Graph.
+
+It wires the Uno extensions host builder with `UseAuthentication(auth => auth.AddMsal(...))` so the provider setup and token-cache lifecycle stay in the host, while the app logic remains intentionally small and portable.
+
+## What it shows
+
+- Sign in with Microsoft Entra ID through the provider's interactive flow
+- Silent refresh with `RefreshAsync()`
+- Logout and token-cache inspection
+- A platform-appropriate redirect URI and a small setup guide for each head
+
+## How to run
+
+1. Register a public client app in the Microsoft Entra admin center and grant the `User.Read` delegated permission.
+2. Paste the Application (client) ID into `Authentication.MsalExtensionsDemo/Authentication/MsalConfig.cs` and into the `Msal.ClientId` value in `appsettings.json`.
+3. Register the redirect URI for the head you are running.
+4. Run the app on the desired target.
+
+See [MSAL-SETUP.md](MSAL-SETUP.md) for the complete platform matrix and troubleshooting notes.
+
+## Notes
+
+This sample deliberately keeps the app logic thin and uses the default Uno.Extensions host configuration. The actual provider integration is the point of the sample: MSAL sign-in is configured with the extensions pipeline and the token cache is consumed through `IAuthenticationService` and `ITokenCache`.

--- a/UI/Authentication.MsalExtensionsDemo/global.json
+++ b/UI/Authentication.MsalExtensionsDemo/global.json
@@ -1,0 +1,9 @@
+{
+  // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
+  "msbuild-sdks": {
+    "Uno.Sdk": "6.6.42"
+  },
+  "sdk": {
+    "allowPrerelease": false
+  }
+}

--- a/UI/Authentication.MsalExtensionsDemo/global.json
+++ b/UI/Authentication.MsalExtensionsDemo/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "6.6.42"
+    "Uno.Sdk": "6.8.0-dev.10"
   },
   "sdk": {
     "allowPrerelease": false

--- a/doc/samples.md
+++ b/doc/samples.md
@@ -114,6 +114,12 @@ This sample application demonstrates signing users in with `Uno.WinUI.MSAL` and 
 
 [Browse source](https://github.com/unoplatform/Uno.Samples/tree/master/UI/Authentication.MsalDemo) | [Read the docs](https://platform.uno/docs/articles/interop/MSAL.html)
 
+### Authentication with MSAL using Uno.Extensions.Authentication.MSAL
+
+This sample demonstrates the `Uno.Extensions.Authentication.MSAL` provider, wiring `UseAuthentication` + `AddMsal` into the Uno host builder and validating the sign-in, refresh, and token-cache flow across desktop, Android, iOS, and WebAssembly.
+
+[Browse source](https://github.com/unoplatform/Uno.Samples/tree/master/UI/Authentication.MsalExtensionsDemo) | [Read the docs](https://github.com/unoplatform/Uno.Samples/blob/master/UI/Authentication.MsalExtensionsDemo/MSAL-SETUP.md)
+
 ### Authentication with OpenID Connect (OIDC)
 
 This sample application demonstrates the usage of the `WebAuthenticationBroker` in Uno with an OpenID Connect endpoint.


### PR DESCRIPTION
## What changed?

Adds `UI/Authentication.MsalExtensionsDemo`, a single-project Uno sample that configures `Uno.Extensions.Authentication.MSAL` through the app host (`UseAuthentication` + `AddMsal`), shows sign-in, silent refresh, logout, and token-cache inspection, and documents the Entra registration and platform redirect URIs for each head.

## Validation

- `dotnet build "UI/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo/Authentication.MsalExtensionsDemo.csproj" -f net10.0-desktop -nologo`
