### PR TITLE
Update Uno.Sdk version and improve MSAL sample documentation

### DIFF
--- a/UI/Authentication.MsalDemo/Authentication.MsalDemo/Authentication.MsalDemo.csproj
+++ b/UI/Authentication.MsalDemo/Authentication.MsalDemo/Authentication.MsalDemo.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Uno.Sdk">
+﻿<Project Sdk="Uno.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-browserwasm;net10.0-desktop</TargetFrameworks>
 
@@ -22,10 +22,9 @@
       https://aka.platform.uno/singleproject-features
     -->
     <!--
-      SkiaRenderer draws every head with Skia rather than native platform elements. Note that it
-      also decides which flavour of Uno.UI.MSAL gets loaded: with it enabled, the WebAssembly head
-      loads the skia build, whose .WithUnoHelpers() is a no-op, and interactive sign-in cannot
-      complete in the browser. See MSAL-SETUP.md before changing this.
+      SkiaRenderer draws every head with Skia rather than native platform elements. It does not
+      change which flavour of Uno.UI.MSAL is loaded: the build deploys the platform flavour
+      (android, ios, webassembly) either way.
     -->
     <UnoFeatures>
       SkiaRenderer;
@@ -44,9 +43,8 @@
       MSAL integration. `Uno.WinUI.MSAL` provides the `.WithUnoHelpers()` extensions that plug
       MSAL.NET into each Uno target. The package ships one Uno.UI.MSAL.dll per runtime flavour: the
       Android and iOS builds supply the parent activity/view controller, the "webassembly" build
-      supplies a popup-based ICustomWebUi and an HttpClient factory, and the "skia" build is a
-      no-op. SkiaRenderer above means every head - WebAssembly included - loads the skia build,
-      which is why interactive sign-in does not work on the WebAssembly head. See MSAL-SETUP.md.
+      supplies a popup-based ICustomWebUi and an HttpClient factory, and the "skia" build - used by
+      Desktop and Windows, where MSAL.NET needs nothing from Uno - is a no-op.
       Microsoft.Identity.Client comes in transitively, but is referenced explicitly here so the
       version is visible and pinnable in Directory.Packages.props.
       See https://aka.platform.uno/msal

--- a/UI/Authentication.MsalDemo/Authentication.MsalDemo/Authentication/AuthenticationService.cs
+++ b/UI/Authentication.MsalDemo/Authentication.MsalDemo/Authentication/AuthenticationService.cs
@@ -103,34 +103,7 @@ internal sealed class AuthenticationService
             .Create(MsalConfig.ClientId)
             .WithAuthority(AzureCloudInstance.AzurePublic, MsalConfig.Tenant)
             .WithRedirectUri(PlatformSupport.RedirectUri)
-            // Uno Platform: this is where .WithUnoHelpers() belongs, and where it will go back once
-            // the issue below is fixed. It wires up the parent activity/view controller on Android
-            // and iOS, and the popup-based web UI plus HttpClient factory on WebAssembly.
-            //
-            // TEMPORARY WORKAROUND for https://github.com/unoplatform/uno/issues/20601:
-            // with the SkiaRenderer feature enabled, every head - Android and iOS included - loads
-            // the "skia" flavour of Uno.UI.MSAL, where .WithUnoHelpers() is a no-op. On Android that
-            // leaves MSAL with no parent Activity and AcquireTokenInteractive fails with
-            // activity_required. The #if branches below supply the same values by hand, from the
-            // same sources the mobile flavours of the package use. There is no WebAssembly branch:
-            // the popup web UI and WasmHttpFactory live only in the "webassembly" flavour, so they
-            // cannot even be referenced from a head that compiles against the skia one.
-            //
-            // The fix is https://github.com/unoplatform/uno/pull/24055, which makes the build deploy
-            // the platform flavour of Uno.UI.MSAL under SkiaRenderer. Once it has merged and shipped,
-            // delete the #if block and restore the single .WithUnoHelpers() call below.
-
-            //.WithUnoHelpers()
-#if ANDROID
-            .WithParentActivityOrWindow(() => Uno.UI.ContextHelper.Current as Android.App.Activity)
-#elif IOS
-            // CA1422: KeyWindow is obsolete for multi-scene apps, but it is exactly what the iOS
-            // flavour of Uno.UI.MSAL reads to resolve the parent. This branch stands in for that
-            // code, so it deliberately resolves the parent the same way rather than a better one.
-#pragma warning disable CA1422
-            .WithParentActivityOrWindow(() => UIKit.UIApplication.SharedApplication?.KeyWindow?.RootViewController)
-#pragma warning restore CA1422
-#endif
+            .WithUnoHelpers()
             .Build();
 
         Log.Success("IPublicClientApplication ready", $"Running on {PlatformSupport.PlatformName}.");

--- a/UI/Authentication.MsalDemo/Authentication.MsalDemo/Authentication/AuthenticationService.cs
+++ b/UI/Authentication.MsalDemo/Authentication.MsalDemo/Authentication/AuthenticationService.cs
@@ -11,45 +11,28 @@ namespace Authentication.MsalDemo.Authentication;
 /// <para>
 /// This is the only type in the sample that talks to MSAL. Two things need a platform-specific
 /// answer - who is the parent of the sign-in UI on mobile, and what shows the web UI in the
-/// browser - and this is how each head gets them:
+/// browser - and <c>.WithUnoHelpers()</c> supplies both. It is the only Uno-specific line in the
+/// flow, called once on the builder in <see cref="GetOrCreateApp"/> and once on the interactive
+/// request in <see cref="AcquireInteractiveAsync"/>.
+/// </para>
+/// <para>
+/// It is not one implementation: <c>Uno.WinUI.MSAL</c> ships a different <c>Uno.UI.MSAL.dll</c> per
+/// runtime flavour and the build deploys the one matching the head, independently of the renderer.
+/// What it does per head:
 /// </para>
 /// <list type="bullet">
-/// <item><description>Android - <c>.WithParentActivityOrWindow(...)</c> on the builder, resolved
-/// from <c>ContextHelper.Current</c>. This is the parent <c>Activity</c> hosting the sign-in
-/// UI; without it <c>AcquireTokenInteractive</c> crashes.</description></item>
-/// <item><description>iOS / Mac Catalyst - <c>.WithParentActivityOrWindow(...)</c> on the builder,
-/// resolved from the key window's <c>RootViewController</c>.</description></item>
-/// <item><description>Desktop (Skia) and Windows - nothing to supply. MSAL.NET launches the system
-/// browser and collects the code on an <c>http://localhost</c> loopback listener.</description></item>
-/// <item><description>WebAssembly - nothing is supplied, and interactive sign-in therefore cannot
-/// complete. See below.</description></item>
+/// <item><description>Android - <c>WithParentActivityOrWindow</c> from <c>ContextHelper.Current</c>.
+/// This is the parent <c>Activity</c> hosting the sign-in UI; without it
+/// <c>AcquireTokenInteractive</c> crashes.</description></item>
+/// <item><description>iOS / Mac Catalyst - <c>WithParentActivityOrWindow</c> from the key window's
+/// <c>RootViewController</c>.</description></item>
+/// <item><description>WebAssembly - an <c>ICustomWebUi</c> that opens a popup with
+/// <c>window.open</c> and polls its URL, plus an <c>IMsalHttpClientFactory</c> that hands MSAL a
+/// browser-backed <c>HttpClient</c>.</description></item>
+/// <item><description>Desktop (Skia) and Windows - nothing, and nothing is needed. MSAL.NET
+/// launches the system browser and collects the code on an <c>http://localhost</c> loopback
+/// listener.</description></item>
 /// </list>
-/// <para>
-/// Those two explicit calls are a <b>temporary workaround</b> for
-/// <see href="https://github.com/unoplatform/uno/issues/20601"/>, not the shape this sample is meant
-/// to show. Normally a single <c>.WithUnoHelpers()</c> on the builder supplies both, from exactly
-/// those two sources - but under the <c>SkiaRenderer</c> feature every head loads the <c>skia</c>
-/// flavour of <c>Uno.UI.MSAL</c>, where the helper is a no-op, so the values have to be set by hand.
-/// <see href="https://github.com/unoplatform/uno/pull/24055"/> fixes that; once it ships, the
-/// <c>#if</c> block in <see cref="GetOrCreateApp"/> goes away and <c>.WithUnoHelpers()</c> comes back.
-/// </para>
-/// <para>
-/// <c>.WithUnoHelpers()</c> is still called on the interactive request in
-/// <see cref="AcquireInteractiveAsync"/>, and is the only Uno-specific line left in the flow. It is
-/// not one implementation, though: the package ships a different <c>Uno.UI.MSAL.dll</c> per runtime
-/// flavour, and the <c>skia</c> one is a no-op. Because the app enables Uno's <c>SkiaRenderer</c>
-/// feature, that no-op flavour is what every head loads - including
-/// <c>net10.0-browserwasm</c>. The <c>ICustomWebUi</c> that opens a browser popup and polls its URL,
-/// and the WASM <c>HttpClient</c> factory, live only in the package's <c>webassembly</c> flavour,
-/// which this app never loads.
-/// </para>
-/// <para>
-/// The consequence on WebAssembly: no web UI is registered, so MSAL falls back to its default one,
-/// which needs to launch a browser process and open a loopback listener. Neither is possible inside
-/// the browser sandbox, so <c>AcquireTokenInteractive</c> cannot complete there. The silent path,
-/// <see cref="GetAccountsAsync"/>, sign-out and the Graph call are unaffected. MSAL-SETUP.md
-/// documents the diagnosis and the options for restoring a browser flow.
-/// </para>
 /// <para>
 /// A singleton is used rather than dependency injection to keep the sample free of any host
 /// builder or Uno.Extensions dependency. In a real app, register this as a singleton service.
@@ -299,10 +282,9 @@ internal sealed class AuthenticationService
             var request = app
                 .AcquireTokenInteractive(MsalConfig.Scopes)
                 .WithPrompt(Prompt.SelectAccount)
-                // Uno Platform: supplies the parent activity/view controller on Android and iOS -
-                // redundantly, since the builder sets it too. A no-op on Desktop, on Windows, and
-                // now on WebAssembly, where the skia flavour of Uno.UI.MSAL that the SkiaRenderer
-                // feature loads no longer brings the popup-based ICustomWebUi.
+                // Uno Platform: supplies the popup-based ICustomWebUi on WebAssembly, and the
+                // parent activity/view controller on Android and iOS - redundantly there, since
+                // the builder already set it. A no-op on Desktop and Windows.
                 .WithUnoHelpers();
 
             if (!string.IsNullOrWhiteSpace(account?.Username))
@@ -327,8 +309,8 @@ internal sealed class AuthenticationService
     {
         AppPlatform.Android => "Chrome custom tab, returning through the msal{ClientId}:// intent filter",
         AppPlatform.AppleUIKit => "ASWebAuthenticationSession, returning through the msauth.{BundleId} URL scheme",
-        AppPlatform.WebAssembly => "none - with the Skia renderer Uno supplies no web UI to MSAL in "
-            + "the browser, so this call cannot complete (see the Platform setup page)",
+        AppPlatform.WebAssembly => "a browser popup opened by Uno's ICustomWebUi, returning to the "
+            + "registered single-page-application redirect URI",
         AppPlatform.Windows => "the system browser, returning to the http://localhost loopback listener",
         _ => "the system browser, returning to the http://localhost loopback listener"
     };
@@ -430,11 +412,9 @@ internal sealed class AuthenticationService
             + $"{PlatformSupport.RedirectUri} on {PlatformSupport.PlatformName}.",
 
         _ when PlatformSupport.Current == AppPlatform.WebAssembly =>
-            "On WebAssembly this is expected, and not a configuration problem: the SkiaRenderer "
-            + "feature makes this head load the skia build of Uno.UI.MSAL, which supplies no "
-            + "ICustomWebUi, so MSAL falls back to a web UI that needs a browser process and a "
-            + "loopback listener - neither of which exists in the browser sandbox. No redirect URI "
-            + "or Entra setting fixes it; see the Platform setup page or MSAL-SETUP.md.",
+            "Check that the popup was not blocked by the browser, and that the redirect URI above "
+            + "is registered under the Single-page application platform - only that type has CORS "
+            + "enabled on the token endpoint. See the Platform setup page or MSAL-SETUP.md.",
 
         _ => "See the Platform setup page for what this head needs."
     };

--- a/UI/Authentication.MsalDemo/Authentication.MsalDemo/Authentication/MsalConfig.cs
+++ b/UI/Authentication.MsalDemo/Authentication.MsalDemo/Authentication/MsalConfig.cs
@@ -64,8 +64,8 @@ internal static class MsalConfig
     /// <c>wwwroot/authentication/login-callback.htm</c>.
     /// </summary>
     /// <remarks>
-    /// Vestigial while the app uses the Skia renderer: no popup is opened on WebAssembly, so
-    /// nothing lands on this path. It remains the registered redirect URI, and MSAL still sends it.
+    /// The popup Uno opens for MSAL lands here, and Uno polls the popup's URL until it matches.
+    /// The page itself does nothing - it only has to exist and be served from this origin.
     /// </remarks>
     public const string WasmRedirectPath = "/authentication/login-callback.htm";
 

--- a/UI/Authentication.MsalDemo/Authentication.MsalDemo/Authentication/PlatformGuide.cs
+++ b/UI/Authentication.MsalDemo/Authentication.MsalDemo/Authentication/PlatformGuide.cs
@@ -111,9 +111,9 @@ internal static class PlatformGuide
                 new(SetupArea.Project,
                     "Nothing to change",
                     """
-                    There is no #if branch for this head, and .WithUnoHelpers() is a no-op in the
-                    skia build of Uno.UI.MSAL that it loads. MSAL.NET does all of the work: it
-                    launches the system browser and collects the code on the loopback listener.
+                    .WithUnoHelpers() is a no-op in the skia build of Uno.UI.MSAL that this head
+                    loads, and nothing else is needed. MSAL.NET does all of the work: it launches
+                    the system browser and collects the code on the loopback listener.
                     """),
 
                 new(SetupArea.Runtime,
@@ -129,32 +129,22 @@ internal static class PlatformGuide
         new(AppPlatform.WebAssembly,
             "WebAssembly",
             "{origin}" + MsalConfig.WasmRedirectPath,
-            "Interactive sign-in does not work on this head with the Skia renderer.",
+            "MSAL shows the sign-in UI in a popup opened by Uno's ICustomWebUi.",
             [
-                new(SetupArea.Runtime,
-                    "Interactive sign-in cannot complete here",
+                new(SetupArea.Project,
+                    "Nothing to change",
                     """
-                    Uno.WinUI.MSAL ships one Uno.UI.MSAL.dll per runtime flavour. The popup web UI -
-                    an ICustomWebUi that opens a window with window.open and polls its URL - exists
-                    only in the "webassembly" flavour. Because this app enables the SkiaRenderer
-                    feature, the browserwasm head loads the "skia" flavour instead, in which
-                    .WithUnoHelpers() is a no-op.
-
-                    With no ICustomWebUi registered, MSAL falls back to its default web UI, which
-                    needs to launch a browser process and listen on a loopback port. Neither is
-                    possible inside the browser sandbox.
-
-                    The silent path, cached accounts, sign-out and the Graph call are unaffected -
-                    only AcquireTokenInteractive is. MSAL-SETUP.md lists the options for restoring a
-                    browser flow; none of them is implemented in this sample.
+                    Uno.WinUI.MSAL ships one Uno.UI.MSAL.dll per runtime flavour, and this head
+                    loads the "webassembly" one. Its .WithUnoHelpers() supplies the ICustomWebUi
+                    that opens the popup with window.open and polls its URL, plus an
+                    IMsalHttpClientFactory so MSAL's HTTP calls go through the browser rather than
+                    through sockets. The SkiaRenderer feature does not change which flavour is
+                    deployed.
                     """),
 
                 new(SetupArea.EntraId,
                     "Register the redirect URI as a Single-page application",
                     $"""
-                    Needed for whenever this head can sign in again - it is a fact about Entra ID,
-                    not about the renderer.
-
                     Authentication > Add a platform > Single-page application, then add the exact
                     origin and path the app is served from, for example:
 
@@ -179,19 +169,17 @@ internal static class PlatformGuide
                 new(SetupArea.Project,
                     "Keep the callback page",
                     """
-                    Platforms/WebAssembly/wwwroot/authentication/login-callback.htm is static
-                    content that a sign-in popup would land on. Nothing opens or polls a popup under
-                    the Skia renderer, so it is vestigial today - but it is still what the
-                    registered redirect URI points at, so keep it if you intend to restore a
-                    browser flow.
+                    Platforms/WebAssembly/wwwroot/authentication/login-callback.htm is the static
+                    page the sign-in popup lands on, and what the registered redirect URI points
+                    at. Uno polls the popup's URL until it matches, then hands it to MSAL. The page
+                    has no script of its own - it only has to exist on this origin.
                     """),
 
                 new(SetupArea.Runtime,
                     "The token cache is in memory",
                     """
-                    Uno does not persist MSAL's cache in the browser, so a page reload signs out.
-                    Moot in practice while interactive sign-in cannot run here: nothing ever
-                    populates the cache.
+                    Uno does not persist MSAL's cache in the browser, so a page reload signs out
+                    and the next run starts with an interactive sign-in.
                     """)
             ]),
 
@@ -235,15 +223,12 @@ internal static class PlatformGuide
                     """),
 
                 new(SetupArea.Project,
-                    "The parent activity is set explicitly",
+                    "The parent activity comes from .WithUnoHelpers()",
                     """
-                    AuthenticationService sets WithParentActivityOrWindow on the builder under
-                    #if ANDROID, resolved from ContextHelper.Current. Calling
-                    AcquireTokenInteractive without a parent activity crashes on Android.
-
-                    .WithUnoHelpers() supplies the same value from the same source on this head, so
-                    the explicit call duplicates it rather than replacing anything - it only removes
-                    the dependency on which flavour of Uno.UI.MSAL the build loaded.
+                    AuthenticationService calls .WithUnoHelpers() on the builder; the android
+                    flavour of Uno.UI.MSAL turns that into WithParentActivityOrWindow, resolved
+                    from ContextHelper.Current. Calling AcquireTokenInteractive without a parent
+                    activity crashes on Android, so this line is not optional here.
                     """),
 
                 new(SetupArea.Runtime,
@@ -281,11 +266,11 @@ internal static class PlatformGuide
                     """),
 
                 new(SetupArea.Project,
-                    "The parent view controller is set explicitly",
+                    "The parent view controller comes from .WithUnoHelpers()",
                     """
-                    AuthenticationService sets WithParentActivityOrWindow on the builder under
-                    #if IOS, resolved from the key window's RootViewController - the same value
-                    .WithUnoHelpers() supplies on this head.
+                    AuthenticationService calls .WithUnoHelpers() on the builder; the ios flavour
+                    of Uno.UI.MSAL turns that into WithParentActivityOrWindow, resolved from the
+                    key window's RootViewController.
                     """),
 
                 new(SetupArea.Project,
@@ -331,9 +316,9 @@ internal static class PlatformGuide
                     "Add the head, change no code",
                     """
                     Add net10.0-windows10.0.19041.0 to <TargetFrameworks> and build on Windows.
-                    There is no #if branch for this head and .WithUnoHelpers() is a no-op on
-                    WinAppSDK, so the authentication code in this sample is unchanged. Like Desktop,
-                    it uses the system browser and the loopback listener.
+                    .WithUnoHelpers() is a no-op on WinAppSDK and nothing else is needed, so the
+                    authentication code in this sample is unchanged. Like Desktop, it uses the
+                    system browser and the loopback listener.
                     """),
 
                 new(SetupArea.Project,

--- a/UI/Authentication.MsalDemo/MSAL-SETUP.md
+++ b/UI/Authentication.MsalDemo/MSAL-SETUP.md
@@ -7,7 +7,7 @@ It uses only:
 
 | Package | Why |
 | --- | --- |
-| `Uno.WinUI.MSAL` | Uno's MSAL add-in. Supplies `.WithUnoHelpers()`, which resolves the parent activity/view controller on Android and iOS. Its WebAssembly helpers — a popup-based web UI and an `HttpClient` factory — are **not** available under the Skia renderer this app uses. |
+| `Uno.WinUI.MSAL` | Uno's MSAL add-in. Supplies `.WithUnoHelpers()`, which resolves the parent activity/view controller on Android and iOS, and a popup-based web UI plus an `HttpClient` factory on WebAssembly. |
 | `Microsoft.Identity.Client` | MSAL.NET itself. |
 
 There is deliberately **no Uno.Extensions** here — no host builder, no DI container, no navigation
@@ -15,11 +15,9 @@ framework. The authentication service is a plain singleton, so you can lift
 `Authentication/AuthenticationService.cs` into an app of any shape.
 
 The app enables Uno's `SkiaRenderer` feature (`<UnoFeatures>` in `Authentication.MsalDemo.csproj`), so every head —
-WebAssembly included — is drawn with Skia rather than native platform elements. That choice decides
-which flavour of `Uno.UI.MSAL.dll` gets loaded and therefore what `.WithUnoHelpers()` actually does.
-It is why **interactive sign-in does not work on the WebAssembly head** as this sample stands; see
-[WebAssembly and the Skia renderer](#webassembly-and-the-skia-renderer). The other three heads are
-unaffected.
+WebAssembly included — is drawn with Skia rather than native platform elements. This does not affect
+MSAL: the build deploys the platform flavour of `Uno.UI.MSAL.dll` (android, ios, webassembly)
+regardless of the renderer, so `.WithUnoHelpers()` does the same thing either way.
 
 Reference: <https://platform.uno/docs/articles/interop/MSAL.html>
 
@@ -78,7 +76,7 @@ must be registered under the right **platform** in **Authentication → Add a pl
 | Head | Redirect URI | Register under | Notes |
 | --- | --- | --- | --- |
 | Desktop (Skia) | `http://localhost` | Mobile and desktop applications | Tick the `http://localhost` checkbox. MSAL picks a free port at runtime, and Entra ID allows any port on `localhost`, so one entry covers them all. |
-| WebAssembly | `http://localhost:5000/authentication/login-callback.htm` | **Single-page application** | Must match your origin exactly. One entry per origin you serve from (dev, staging, production). Registering it does not make this head sign in — see [WebAssembly and the Skia renderer](#webassembly-and-the-skia-renderer). |
+| WebAssembly | `http://localhost:5000/authentication/login-callback.htm` | **Single-page application** | Must match your origin exactly. One entry per origin you serve from (dev, staging, production). |
 | Android | `msal{ClientId}://auth` | Mobile and desktop applications → *Custom redirect URI* | For example `msal00000000-0000-0000-0000-000000000000://auth`. |
 | iOS / Mac Catalyst | `msauth.com.companyname.authentication.msaldemo://auth` | iOS/macOS | Enter the bundle ID (`<ApplicationId>` in `Authentication.MsalDemo.csproj`) and the portal builds the URI. |
 | Windows (WinAppSDK) | `http://localhost` | Mobile and desktop applications | Not one of this sample's four heads; see [Adding a Windows head](#adding-a-windows-head). |
@@ -88,11 +86,9 @@ The running app always shows the value it computed, under **Redirect URI to regi
 
 ### WebAssembly must be registered as a Single-page application
 
-Background for whenever the WebAssembly head can sign in again — it is a fact about Entra ID, not
-about the renderer, so it stays true. In the browser, MSAL redeems the authorization code with a
-`fetch` call from your origin, and **only SPA-type redirect URIs have CORS enabled on the token
-endpoint**. Register the same URI under *Mobile and desktop applications* instead and sign-in fails
-with:
+In the browser, MSAL redeems the authorization code with a `fetch` call from your origin, and **only
+SPA-type redirect URIs have CORS enabled on the token endpoint**. Register the same URI under
+*Mobile and desktop applications* instead and sign-in fails with:
 
 > cross-origin token redemption is permitted only for the 'Single-Page Application' client-type
 
@@ -156,14 +152,9 @@ dotnet run --project Authentication.MsalDemo/Authentication.MsalDemo.csproj -f n
 The port matters — it is part of the origin, and therefore part of the redirect URI you registered.
 `http://localhost:5000` comes from `Authentication.MsalDemo/Properties/launchSettings.json`.
 
-> **Interactive sign-in does not work on this head.** The app builds, runs and navigates, and the
-> *Sign in* page still shows the resolved configuration, the platform and the redirect URI — but
-> pressing **Sign in** cannot show a sign-in UI, because under the Skia renderer Uno supplies no
-> web UI to MSAL in the browser. [WebAssembly and the Skia
-> renderer](#webassembly-and-the-skia-renderer) explains why and what the options are.
->
-> This also makes the old `Cross-Origin-Opener-Policy` advice moot: COOP mattered only because Uno
-> used to read a popup's URL to extract the authorization code, and there is no popup any more.
+> Sign-in opens a popup, and Uno reads that popup's URL to extract the authorization code. If you
+> serve the app behind a `Cross-Origin-Opener-Policy` header, the opener loses its handle on the
+> popup and the flow hangs — leave COOP unset, or use `unsafe-none`, on the origin serving the app.
 
 **Android** (emulator or device connected)
 
@@ -186,7 +177,7 @@ dotnet build Authentication.MsalDemo/Authentication.MsalDemo.csproj -f net10.0-i
 | `Authentication/MsalConfig.cs` | The only file you edit: client ID, tenant, scopes. |
 | `Authentication/AuthenticationService.cs` | All MSAL usage. Builds the `IPublicClientApplication`, runs silent-then-interactive acquisition, signs out, and narrates every step. |
 | `Authentication/PlatformSupport.cs` | `partial` declaration of the per-platform facts (redirect URI, platform name). |
-| `Platforms/<platform>/PlatformSupport.*.cs` | One implementation per head. Uno's single project compiles only the folder matching the target framework, so these files need no `#if` blocks — and adding a head without giving MSAL a redirect URI is a compile error. (`AuthenticationService` itself does use `#if`, for the parent activity/window.) |
+| `Platforms/<platform>/PlatformSupport.*.cs` | One implementation per head. Uno's single project compiles only the folder matching the target framework, so these files need no `#if` blocks — and adding a head without giving MSAL a redirect URI is a compile error. |
 | `Authentication/PlatformGuide.cs` | The reference content shown on the *Platform setup* page. |
 | `Authentication/AuthFlowLog.cs` | The observable step-by-step log. |
 | `Services/GraphClient.cs` | The Microsoft Graph `/me` call. |
@@ -202,7 +193,7 @@ Platform plumbing:
 | `Platforms/iOS/Main.iOS.cs` | Installs it with `.UseAppleUIKit(b => b.UseUIApplicationDelegate<MsalAppDelegate>())`. |
 | `Platforms/iOS/Info.plist` | Declares the `msauth.<bundle id>` URL scheme. |
 | `Platforms/iOS/Entitlements.plist` | Grants the `$(AppIdentifierPrefix)com.microsoft.adalcache` keychain access group. MSAL stores its token cache in the keychain and reads the publisher's Team ID back out of it, so without this entitlement `PublicClientApplicationBuilder.Build()` throws `cannot_access_publisher_keychain`. The Uno SDK picks this file up automatically as `CodesignEntitlements`. |
-| `Platforms/WebAssembly/wwwroot/authentication/login-callback.htm` | Static page on our own origin for a sign-in popup to land on. Vestigial under the Skia renderer — nothing opens or polls a popup any more — but it is still what the registered SPA redirect URI points at, so keep it if you intend to restore a browser flow. |
+| `Platforms/WebAssembly/wwwroot/authentication/login-callback.htm` | Static page on our own origin for the sign-in popup to land on, and what the registered SPA redirect URI points at. Uno polls the popup's URL until it matches this one. The page needs no script of its own — it only has to exist. |
 
 ---
 
@@ -241,8 +232,8 @@ warning step, not an error, precisely to make that clear.
 ### What supplies the platform-specific pieces
 
 Two things need a platform answer: **who is the parent** of the sign-in UI on mobile, and **what
-shows the web UI** in the browser. Normally `.WithUnoHelpers()` answers both. Right now it cannot,
-so the parent is set explicitly on the builder in `GetOrCreateApp`:
+shows the web UI** in the browser. `.WithUnoHelpers()` answers both, and it is the only Uno-specific
+line in the flow — once on the builder in `GetOrCreateApp`, once on the interactive request:
 
 ```csharp
 _app = PublicClientApplicationBuilder
@@ -253,63 +244,18 @@ _app = PublicClientApplicationBuilder
     .Build();
 ```
 
-> [!IMPORTANT]
-> **This `#if` block is a temporary workaround for
-> [unoplatform/uno#20601](https://github.com/unoplatform/uno/issues/20601).** With the `SkiaRenderer`
-> feature enabled, every head loads the `skia` flavour of `Uno.UI.MSAL`, where `.WithUnoHelpers()` is
-> a no-op — so on Android MSAL is left with no parent `Activity` and `AcquireTokenInteractive` fails
-> with `activity_required`. The fix is
-> [unoplatform/uno#24055](https://github.com/unoplatform/uno/pull/24055), which makes the build
-> deploy the platform flavour of `Uno.UI.MSAL` under `SkiaRenderer`. **Once it has merged and
-> shipped, delete the `#if` block and restore the single `.WithUnoHelpers()` call.**
+It is not one implementation. `Uno.WinUI.MSAL` ships a different `Uno.UI.MSAL.dll` per runtime
+flavour, and the build deploys the one matching the head:
 
-On Android and iOS these are the same values a working `.WithUnoHelpers()` supplies — the package's
-mobile builds resolve them from `ContextHelper.Current` and the key window's `RootViewController`
-respectively — so the explicit calls stand in for the helper rather than doing anything different.
-Desktop and Windows need neither branch: MSAL.NET launches the system browser and collects the code
-on an `http://localhost` loopback listener. There is no WebAssembly branch either, because the popup
-web UI and `WasmHttpFactory` exist only in the `webassembly` flavour of the assembly and cannot be
-referenced from a head that compiles against the `skia` one — see the next section.
+| Flavour in the package | Used by | What `.WithUnoHelpers()` does there |
+| --- | --- | --- |
+| `lib/net10.0-android`, `lib/net10.0-ios26.0` | `net10.0-android`, `net10.0-ios` | Supplies `WithParentActivityOrWindow` from `ContextHelper.Current` / the key window's `RootViewController`. Without it `AcquireTokenInteractive` fails with `activity_required` on Android. |
+| `uno-runtime/net10.0/webassembly` | `net10.0-browserwasm` | Supplies a `WasmWebUi` — an `ICustomWebUi` that opens a popup with `window.open` and polls its URL — plus an `IMsalHttpClientFactory` so MSAL's HTTP goes through the browser rather than through sockets. |
+| `uno-runtime/net10.0/skia` | `net10.0-desktop`, WinAppSDK | Nothing, and nothing is needed: MSAL.NET launches the system browser and collects the code on an `http://localhost` loopback listener. |
 
-`.WithUnoHelpers()` on the interactive request (step 3 above) is still called, unconditionally, and
-is the only Uno-specific line left in the flow. It is a no-op today for the same reason, and starts
-working again with the same fix.
-
----
-
-## WebAssembly and the Skia renderer
-
-`.WithUnoHelpers()` is not one implementation. `Uno.WinUI.MSAL` ships a different `Uno.UI.MSAL.dll`
-per runtime flavour, and the build picks one:
-
-| Flavour in the package | What `.WithUnoHelpers()` does there |
-| --- | --- |
-| `lib/net10.0-android`, `lib/net10.0-ios26.0` | Supplies `WithParentActivityOrWindow` from `ContextHelper.Current` / the key window's `RootViewController`. |
-| `uno-runtime/net10.0/webassembly` | Supplies a `WasmWebUi` — an `ICustomWebUi` that opens a popup with `window.open` and polls its URL — plus an `IMsalHttpClientFactory`. |
-| `uno-runtime/net10.0/skia` | Nothing. It is a no-op. |
-
-Because `<UnoFeatures>SkiaRenderer</UnoFeatures>` is enabled, the **`skia` flavour is what the
-`net10.0-browserwasm` head deploys** — the `Uno.UI.MSAL.dll` in
-`bin/Debug/net10.0-browserwasm/` is byte-for-byte the one from `uno-runtime/net10.0/skia`, not the
-`webassembly` one. The popup web UI is in a file this app never loads.
-
-So on the WebAssembly head no `ICustomWebUi` is registered, and `AcquireTokenInteractive` falls back
-to MSAL.NET's default web UI — which launches a browser process and listens on a loopback port.
-Neither is possible from inside the browser sandbox, so the interactive call cannot complete. The
-silent path, `GetAccountsAsync`, sign-out and the Graph call are all unaffected; only interactive
-sign-in is.
-
-### Options, none of them implemented here
-
-- **Build the WebAssembly head without the Skia renderer**, so the `webassembly` flavour of the
-  package is loaded and the popup flow returns. `<UnoFeatures>` can be set per target framework.
-  This gives up Skia rendering on that head, and it has not been tried in this repository.
-- **Supply your own `ICustomWebUi`** and pass it with `.WithCustomWebUi(...)`. It has to open a
-  window, wait until its URL is the redirect URI, and return that URI to MSAL — the same contract
-  `WasmWebUi` implements. This is renderer-independent, but it is code you write and maintain.
-
-Both are directions rather than verified recipes. What *is* verified is the diagnosis above: the
-deployed assembly is the no-op one.
+The `SkiaRenderer` feature does not change that selection — every head gets its own flavour, so
+`.WithUnoHelpers()` is the same single line everywhere and there is no `#if` anywhere in
+`AuthenticationService`.
 
 ---
 
@@ -322,7 +268,8 @@ deployed assembly is the no-op one.
 | `unauthorized_client` or `invalid_client` | Not registered as a public client, or the client ID does not exist in the tenant | **Authentication → Allow public client flows → Yes**, and check `MsalConfig.ClientId` / `Tenant`. |
 | `access_denied` | Consent declined | The user or an administrator refused the requested scopes. |
 | `authentication_canceled` | The user closed the sign-in window | On Android, iOS and Desktop this means what it says. |
-| **WebAssembly:** pressing *Sign in* fails or does nothing after the silent step | Not a configuration problem — no web UI is available to MSAL in the browser under the Skia renderer | [WebAssembly and the Skia renderer](#webassembly-and-the-skia-renderer). No redirect URI or Entra setting fixes this. |
+| **WebAssembly:** the popup opens and never closes | `Cross-Origin-Opener-Policy` on the serving origin, so the app loses its handle on the popup | Leave COOP unset or set it to `unsafe-none`. |
+| **WebAssembly:** the popup is blocked | The browser blocked `window.open` | Sign-in must be triggered by a user gesture; allow popups for the origin. |
 | **Android:** app hangs after signing in | `OnActivityResult` not forwarded, or no intent filter for the scheme | Both are wired in this sample; if you copied only part of it, check `MsalActivity.Android.cs` and `MainActivity.OnActivityResult`. |
 | **Android:** `AndroidActivityNotFound` | No browser on the device | Install one; prefer a browser with custom tab support. |
 | **iOS:** browser closes and nothing happens | `CFBundleURLSchemes` missing or not `msauth.<bundle id>`, or `OpenUrl` not forwarded | Check `Info.plist` and `MsalAppDelegate.iOS.cs`. |
@@ -378,8 +325,8 @@ keep the dependency list to MSAL alone.
 
 ## Adding a Windows head
 
-There is no `#if` branch for Windows and `.WithUnoHelpers()` is a no-op on WinAppSDK, so **no
-authentication code changes**. Like Desktop, it uses the system browser and the loopback listener.
+`.WithUnoHelpers()` is a no-op on WinAppSDK and nothing else is needed, so **no authentication code
+changes**. Like Desktop, it uses the system browser and the loopback listener.
 Add the target framework and build on Windows:
 
 ```xml

--- a/UI/Authentication.MsalDemo/MSAL-SETUP.md
+++ b/UI/Authentication.MsalDemo/MSAL-SETUP.md
@@ -249,12 +249,7 @@ _app = PublicClientApplicationBuilder
     .Create(MsalConfig.ClientId)
     .WithAuthority(AzureCloudInstance.AzurePublic, MsalConfig.Tenant)
     .WithRedirectUri(PlatformSupport.RedirectUri)
-    //.WithUnoHelpers()        // ← temporary workaround, see below
-#if ANDROID
-    .WithParentActivityOrWindow(() => Uno.UI.ContextHelper.Current as Android.App.Activity)
-#elif IOS
-    .WithParentActivityOrWindow(() => UIKit.UIApplication.SharedApplication?.KeyWindow?.RootViewController)
-#endif
+    .WithUnoHelpers()
     .Build();
 ```
 

--- a/UI/Authentication.MsalDemo/README.md
+++ b/UI/Authentication.MsalDemo/README.md
@@ -13,9 +13,7 @@ Tested on:
 - [x] Desktop (Skia)
 - [x] Android
 - [x] iOS
-- [ ] WebAssembly — builds and runs, but interactive sign-in cannot complete under the Skia
-      renderer. See [MSAL-SETUP.md](MSAL-SETUP.md#webassembly-and-the-skia-renderer) for the
-      diagnosis and the options.
+- [x] WebAssembly
 
 ## What it shows
 
@@ -40,30 +38,6 @@ Tested on:
 [MSAL-SETUP.md](MSAL-SETUP.md) walks through all of this in detail — the registration, the redirect
 URI per platform, the per-head project requirements, and a troubleshooting table mapping the MSAL
 error codes you are most likely to hit onto their fix.
-
-## Note: temporary workaround for unoplatform/uno#20601
-
-`GetOrCreateApp` in `Authentication/AuthenticationService.cs` currently supplies the parent
-`Activity` / `UIViewController` by hand behind `#if ANDROID` / `#elif IOS`, with `.WithUnoHelpers()`
-commented out directly above it:
-
-```csharp
-//.WithUnoHelpers()
-#if ANDROID
-    .WithParentActivityOrWindow(() => Uno.UI.ContextHelper.Current as Android.App.Activity)
-#elif IOS
-    .WithParentActivityOrWindow(() => UIKit.UIApplication.SharedApplication?.KeyWindow?.RootViewController)
-#endif
-```
-
-This works around [unoplatform/uno#20601](https://github.com/unoplatform/uno/issues/20601): with the
-`SkiaRenderer` feature enabled, every head loads the `skia` flavour of `Uno.UI.MSAL`, where
-`.WithUnoHelpers()` is a no-op — so on Android MSAL is left with no parent `Activity` and
-`AcquireTokenInteractive` fails with `activity_required`.
-
-The fix is [unoplatform/uno#24055](https://github.com/unoplatform/uno/pull/24055). **Once it has
-merged and shipped, the `#if` block should be deleted and the single `.WithUnoHelpers()` call
-restored** — that is the shape this sample is meant to demonstrate.
 
 ## Relevant documentation
 

--- a/UI/Authentication.MsalDemo/global.json
+++ b/UI/Authentication.MsalDemo/global.json
@@ -1,7 +1,7 @@
 {
   // To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
   "msbuild-sdks": {
-    "Uno.Sdk": "6.6.42"
+    "Uno.Sdk": "6.8.0-dev.19"
   },
   "sdk": {
     "allowPrerelease": false


### PR DESCRIPTION
This pull request updates the Uno Platform MSAL authentication sample to reflect changes in how MSAL integration works across platforms, particularly with the SkiaRenderer feature. The documentation, code comments, and runtime logic are revised to clarify that the correct platform-specific MSAL implementation is now loaded regardless of the renderer, restoring interactive sign-in support on WebAssembly and simplifying platform-specific logic. The sample now consistently uses `.WithUnoHelpers()` to configure MSAL on all platforms, removing previous workarounds.

**MSAL Integration and Platform Support Updates:**

* Updated the MSAL configuration and authentication flow to always call `.WithUnoHelpers()` on the MSAL builder, removing platform-specific workarounds for Android and iOS and restoring interactive sign-in support on WebAssembly. [[1]](diffhunk://#diff-bba704abb5fcccb024ae139bc188f2cf46e8423b6409efc5b4052ad1f346cdbfL106-R89) [[2]](diffhunk://#diff-bba704abb5fcccb024ae139bc188f2cf46e8423b6409efc5b4052ad1f346cdbfL329-R287)
* Revised comments and documentation in `AuthenticationService.cs` to accurately describe the role of `.WithUnoHelpers()` and how Uno.WinUI.MSAL provides platform-specific helpers for Android, iOS, WebAssembly, Desktop, and Windows.

**WebAssembly and SkiaRenderer Clarifications:**

* Updated documentation and user-facing messages to clarify that on WebAssembly, Uno supplies an `ICustomWebUi` that opens a popup for sign-in and uses the correct HTTP client, regardless of the SkiaRenderer setting. Removed obsolete explanations about the SkiaRenderer disabling interactive sign-in on WebAssembly. [[1]](diffhunk://#diff-bba704abb5fcccb024ae139bc188f2cf46e8423b6409efc5b4052ad1f346cdbfL357-R313) [[2]](diffhunk://#diff-bba704abb5fcccb024ae139bc188f2cf46e8423b6409efc5b4052ad1f346cdbfL460-R417) [[3]](diffhunk://#diff-3bcf2610affa59262d4d30da3c7dafc7075e2bb9c8a4c3cc68b1ce14ae590925L67-R68) [[4]](diffhunk://#diff-bd5e0b9b792ef81f5bcc59db0f36d77b0e231cf8ec02b8121fe4fa6ca54ab99eL132-L157) [[5]](diffhunk://#diff-bd5e0b9b792ef81f5bcc59db0f36d77b0e231cf8ec02b8121fe4fa6ca54ab99eL182-R182)

**Platform Guide and Setup Instructions:**

* Revised `PlatformGuide.cs` to reflect that `.WithUnoHelpers()` is a no-op only on Desktop/Windows (Skia), and that on Android and iOS, it supplies the parent activity/view controller as needed. Updated WebAssembly guidance to show that interactive sign-in works and explain the popup-based flow. [[1]](diffhunk://#diff-bd5e0b9b792ef81f5bcc59db0f36d77b0e231cf8ec02b8121fe4fa6ca54ab99eL114-R116) [[2]](diffhunk://#diff-bd5e0b9b792ef81f5bcc59db0f36d77b0e231cf8ec02b8121fe4fa6ca54ab99eL238-R231) [[3]](diffhunk://#diff-bd5e0b9b792ef81f5bcc59db0f36d77b0e231cf8ec02b8121fe4fa6ca54ab99eL284-R273) [[4]](diffhunk://#diff-bd5e0b9b792ef81f5bcc59db0f36d77b0e231cf8ec02b8121fe4fa6ca54ab99eL334-R321)

**Project File and Build Comments:**

* Updated comments in `Authentication.MsalDemo.csproj` to clarify that SkiaRenderer does not affect which MSAL implementation is loaded; the correct platform-specific Uno.UI.MSAL is always deployed. [[1]](diffhunk://#diff-b4c970fdedd9f18443fe04017a4a6248d6537f3370f0c60e10d950495e1aa327L25-R27) [[2]](diffhunk://#diff-b4c970fdedd9f18443fe04017a4a6248d6537f3370f0c60e10d950495e1aa327L47-R47)

These changes ensure the sample accurately demonstrates current Uno Platform MSAL integration patterns and provides clear guidance for all supported platforms.